### PR TITLE
Filter negative MCIDs before ID mapping

### DIFF
--- a/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
+++ b/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
@@ -10,14 +10,16 @@ export function StructElementComponent({ element, scale, mcidMap }: Props) {
   const Tag = (element.htmlTag || 'span') as any;
   //const Tag = ('span') as any;
 
-  const existingIds = element.mcids
+  const mcids = element.mcids.filter((mcid) => mcid >= 0);
+
+  const existingIds = mcids
     .map((mcid) => mcidMap.get(mcid))
     .filter((id): id is string => Boolean(id));
 
   let id: string | undefined;
-  if (existingIds.length === 0 && element.mcids.length) {
-    id = `mcid-${element.mcids[0]}`;
-    element.mcids.forEach((mcid) => mcidMap.set(mcid, id!));
+  if (existingIds.length === 0 && mcids.length) {
+    id = `mcid-${mcids[0]}`;
+    mcids.forEach((mcid) => mcidMap.set(mcid, id!));
   }
 
   const ariaProps = existingIds.length ? { 'aria-labelledby': existingIds.join(' ') } : {};


### PR DESCRIPTION
## Summary
- Ignore negative MCIDs before mapping or generating IDs to avoid invalid aria-labelledby references

## Testing
- `pnpm --filter @embedpdf/plugin-a11y lint` *(fails: pnpm not found)*
- `apt-get update` *(fails: repository 403 / not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b994003d60832d83692c3b062e38e5