### PR TITLE
fix(plugin-a11y): output text on first occurrence of struct element

### DIFF
--- a/.changeset/ensure-text-output.md
+++ b/.changeset/ensure-text-output.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-a11y': patch
+---
+
+Fix text rendering so first occurrence outputs text and sets an id for subsequent aria-labelledby references.

--- a/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
+++ b/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export function StructElementComponent({ element, scale, mcidMap }: Props) {
   const Tag = (element.htmlTag || 'span') as any;
-  //const Tag = ('span') as any;
+  // const Tag = ('span') as any;
 
   const mcids = element.mcids.filter((mcid) => mcid >= 0);
 
@@ -16,10 +16,12 @@ export function StructElementComponent({ element, scale, mcidMap }: Props) {
     .map((mcid) => mcidMap.get(mcid))
     .filter((id): id is string => Boolean(id));
 
+  const newMcids = mcids.filter((mcid) => !mcidMap.has(mcid));
+
   let id: string | undefined;
-  if (existingIds.length === 0 && mcids.length) {
-    id = `mcid-${mcids[0]}`;
-    mcids.forEach((mcid) => mcidMap.set(mcid, id!));
+  if (newMcids.length) {
+    id = `mcid-${newMcids[0]}`;
+    newMcids.forEach((mcid) => mcidMap.set(mcid, id!));
   }
 
   const ariaProps = existingIds.length ? { 'aria-labelledby': existingIds.join(' ') } : {};
@@ -33,8 +35,14 @@ export function StructElementComponent({ element, scale, mcidMap }: Props) {
   };
 
   return (
-    <Tag {...element.attributes} {...(id && { id })} {...ariaProps} style={style} data-pdftag={element.tag}>
-      {existingIds.length ? null : element.text}
+    <Tag
+      {...element.attributes}
+      {...(id && { id })}
+      {...ariaProps}
+      style={style}
+      data-pdftag={element.tag}
+    >
+      {newMcids.length ? element.text : null}
       {element.children.map((child, i) => (
         <StructElementComponent key={i} element={child} scale={scale} mcidMap={mcidMap} />
       ))}


### PR DESCRIPTION
## Summary
- fix `StructElementComponent` to render text on first MCID occurrence and reference previous ids with `aria-labelledby`
- add changeset for @embedpdf/plugin-a11y

## Testing
- `pnpm --filter @embedpdf/plugin-a11y lint`
- `pnpm --filter @embedpdf/plugin-a11y build:base` *(fails: Cannot find package '@embedpdf/build')*


------
https://chatgpt.com/codex/tasks/task_e_68b996508030832db515746b58ad21e6