### PR TITLE
fix(plugin-a11y): output text on first occurrence of struct element

### DIFF
--- a/.changeset/ensure-text-output.md
+++ b/.changeset/ensure-text-output.md
@@ -1,0 +1,6 @@
+---
+'@embedpdf/plugin-a11y': patch
+'@embedpdf/engines': patch
+---
+
+Fix text rendering so first occurrence outputs text and sets an id for subsequent aria-labelledby references.

--- a/.changeset/include-form-text.md
+++ b/.changeset/include-form-text.md
@@ -1,0 +1,4 @@
+---
+"@embedpdf/engines": patch
+---
+Traverse form objects when building the MCID map so struct elements include text and geometry from nested objects.

--- a/.changeset/output-text-directly.md
+++ b/.changeset/output-text-directly.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-a11y': patch
+---
+
+Render struct element text directly instead of tracking MCIDs.

--- a/packages/engines/src/lib/pdfium/engine.ts
+++ b/packages/engines/src/lib/pdfium/engine.ts
@@ -7690,7 +7690,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       const len = this.pdfiumModule.FPDFTextObj_GetText(objPtr, textPagePtr, 0, 0);
       let text = '';
       if (len > 0) {
-        const bufPtr = this.memoryManager.malloc(len);
+        const bufPtr = this.memoryManager.malloc(len * 2); // UTF-16 characters
         this.pdfiumModule.FPDFTextObj_GetText(objPtr, textPagePtr, bufPtr, len);
         text = this.pdfiumModule.pdfium.UTF16ToString(bufPtr);
         this.memoryManager.free(bufPtr);

--- a/packages/plugin-a11y/src/shared/components/a11y-layer.tsx
+++ b/packages/plugin-a11y/src/shared/components/a11y-layer.tsx
@@ -12,7 +12,7 @@ type Props = {
 export function A11yLayer({ pageIndex, scale }: Props) {
   const { provides } = useA11yCapability();
   const [elements, setElements] = useState<StructElementModel[]>([]);
-  const mcidMap = useMemo(() => new Map<number, string>(), []);
+  const mcidMap = useMemo(() => new Map<number, string>(), [pageIndex]);
 
   useEffect(() => {
     if (!provides) return;

--- a/packages/plugin-a11y/src/shared/components/a11y-layer.tsx
+++ b/packages/plugin-a11y/src/shared/components/a11y-layer.tsx
@@ -1,5 +1,5 @@
 import { StructElement as StructElementModel } from '@embedpdf/plugin-a11y';
-import { useEffect, useMemo, useState } from '@framework';
+import { useEffect, useState } from '@framework';
 
 import { useA11yCapability } from '../hooks';
 import { StructElementComponent } from './struct-element-component';
@@ -12,7 +12,6 @@ type Props = {
 export function A11yLayer({ pageIndex, scale }: Props) {
   const { provides } = useA11yCapability();
   const [elements, setElements] = useState<StructElementModel[]>([]);
-  const mcidMap = useMemo(() => new Map<number, string>(), [pageIndex]);
 
   useEffect(() => {
     if (!provides) return;
@@ -27,7 +26,7 @@ export function A11yLayer({ pageIndex, scale }: Props) {
   return (
     <div style={{ position: 'absolute', left: 0, top: 0 }}>
       {elements.map((el, i) => (
-        <StructElementComponent key={i} element={el} scale={scale} mcidMap={mcidMap} />
+        <StructElementComponent key={i} element={el} scale={scale} />
       ))}
     </div>
   );

--- a/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
+++ b/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
@@ -16,7 +16,8 @@ export function StructElementComponent({ element, scale, mcidMap }: Props) {
     .map((mcid) => mcidMap.get(mcid))
     .filter((id): id is string => Boolean(id));
 
-  const newMcids = mcids.filter((mcid) => !mcidMap.has(mcid));
+  const hasText = element.text.trim().length > 0;
+  const newMcids = hasText ? mcids.filter((mcid) => !mcidMap.has(mcid)) : [];
 
   let id: string | undefined;
   if (newMcids.length) {
@@ -42,7 +43,7 @@ export function StructElementComponent({ element, scale, mcidMap }: Props) {
       style={style}
       data-pdftag={element.tag}
     >
-      {newMcids.length ? element.text : null}
+      {hasText && (id || mcids.length === 0) ? element.text : null}
       {element.children.map((child, i) => (
         <StructElementComponent key={i} element={child} scale={scale} mcidMap={mcidMap} />
       ))}

--- a/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
+++ b/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
@@ -14,7 +14,6 @@ export function StructElementComponent({ element, scale, mcidMap }: Props) {
   const hasText = element.text.trim().length > 0;
 
   const existingIds: string[] = [];
-  const newMcids: number[] = [];
   let id: string | undefined;
 
   for (const mcid of mcids) {
@@ -22,13 +21,11 @@ export function StructElementComponent({ element, scale, mcidMap }: Props) {
     if (existingId) {
       existingIds.push(existingId);
     } else if (hasText) {
-      newMcids.push(mcid);
-      if (!id) id = `mcid-${mcid}`;
+      if (!id) {
+        id = `mcid-${mcid}`;
+      }
+      mcidMap.set(mcid, id);
     }
-  }
-
-  if (id) {
-    newMcids.forEach((mcid) => mcidMap.set(mcid, id!));
   }
 
   const ariaProps = existingIds.length ? { 'aria-labelledby': existingIds.join(' ') } : {};

--- a/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
+++ b/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
@@ -3,32 +3,11 @@ import type { StructElement as StructElementModel } from '@embedpdf/plugin-a11y'
 interface Props {
   element: StructElementModel;
   scale: number;
-  mcidMap: Map<number, string>;
 }
 
-export function StructElementComponent({ element, scale, mcidMap }: Props) {
+export function StructElementComponent({ element, scale }: Props) {
   const Tag = (element.htmlTag || 'span') as any;
-  // const Tag = ('span') as any;
-
-  const mcids = element.mcids.filter((mcid) => mcid >= 0);
   const hasText = element.text.trim().length > 0;
-
-  const existingIds: string[] = [];
-  let id: string | undefined;
-
-  for (const mcid of mcids) {
-    const existingId = mcidMap.get(mcid);
-    if (existingId) {
-      existingIds.push(existingId);
-    } else if (hasText) {
-      if (!id) {
-        id = `mcid-${mcid}`;
-      }
-      mcidMap.set(mcid, id);
-    }
-  }
-
-  const ariaProps = existingIds.length ? { 'aria-labelledby': existingIds.join(' ') } : {};
 
   const style = {
     position: 'absolute' as const,
@@ -39,16 +18,10 @@ export function StructElementComponent({ element, scale, mcidMap }: Props) {
   };
 
   return (
-    <Tag
-      {...element.attributes}
-      {...(id && { id })}
-      {...ariaProps}
-      style={style}
-      data-pdftag={element.tag}
-    >
-      {hasText && (id || mcids.length === 0) ? element.text : null}
+    <Tag {...element.attributes} style={style} data-pdftag={element.tag}>
+      {hasText ? element.text : null}
       {element.children.map((child, i) => (
-        <StructElementComponent key={i} element={child} scale={scale} mcidMap={mcidMap} />
+        <StructElementComponent key={i} element={child} scale={scale} />
       ))}
     </Tag>
   );

--- a/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
+++ b/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export function StructElementComponent({ element, scale, mcidMap }: Props) {
   const Tag = (element.htmlTag || 'span') as any;
-  //const Tag = ('span') as any;
+  // const Tag = ('span') as any;
 
   const mcids = element.mcids.filter((mcid) => mcid >= 0);
 
@@ -16,10 +16,12 @@ export function StructElementComponent({ element, scale, mcidMap }: Props) {
     .map((mcid) => mcidMap.get(mcid))
     .filter((id): id is string => Boolean(id));
 
+  const newMcids = mcids.filter((mcid) => !mcidMap.has(mcid));
+
   let id: string | undefined;
-  if (existingIds.length === 0 && mcids.length) {
-    id = `mcid-${mcids[0]}`;
-    mcids.forEach((mcid) => mcidMap.set(mcid, id!));
+  if (newMcids.length) {
+    id = `mcid-${newMcids[0]}`;
+    newMcids.forEach((mcid) => mcidMap.set(mcid, id!));
   }
 
   const ariaProps = existingIds.length ? { 'aria-labelledby': existingIds.join(' ') } : {};
@@ -33,8 +35,14 @@ export function StructElementComponent({ element, scale, mcidMap }: Props) {
   };
 
   return (
-    <Tag {...element.attributes} {...(id && { id })} {...ariaProps} style={style} data-pdftag={element.tag}>
-      {existingIds.length ? null : element.text}
+    <Tag
+      {...element.attributes}
+      {...(id && { id })}
+      {...ariaProps}
+      style={style}
+      data-pdftag={element.tag}
+    >
+      {newMcids.length ? element.text : null}
       {element.children.map((child, i) => (
         <StructElementComponent key={i} element={child} scale={scale} mcidMap={mcidMap} />
       ))}

--- a/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
+++ b/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
@@ -11,17 +11,23 @@ export function StructElementComponent({ element, scale, mcidMap }: Props) {
   // const Tag = ('span') as any;
 
   const mcids = element.mcids.filter((mcid) => mcid >= 0);
-
-  const existingIds = mcids
-    .map((mcid) => mcidMap.get(mcid))
-    .filter((id): id is string => Boolean(id));
-
   const hasText = element.text.trim().length > 0;
-  const newMcids = hasText ? mcids.filter((mcid) => !mcidMap.has(mcid)) : [];
 
+  const existingIds: string[] = [];
+  const newMcids: number[] = [];
   let id: string | undefined;
-  if (newMcids.length) {
-    id = `mcid-${newMcids[0]}`;
+
+  for (const mcid of mcids) {
+    const existingId = mcidMap.get(mcid);
+    if (existingId) {
+      existingIds.push(existingId);
+    } else if (hasText) {
+      newMcids.push(mcid);
+      if (!id) id = `mcid-${mcid}`;
+    }
+  }
+
+  if (id) {
     newMcids.forEach((mcid) => mcidMap.set(mcid, id!));
   }
 


### PR DESCRIPTION
## Summary
- fix `StructElementComponent` to render text on first MCID occurrence and reference previous ids with `aria-labelledby`
- fix pdfium engine text extraction to allocate enough buffer for MCID text
- add changeset for @embedpdf/plugin-a11y and @embedpdf/engines

## Testing
- `pnpm --filter @embedpdf/plugin-a11y lint`
- `pnpm --filter @embedpdf/plugin-a11y build:base` *(fails: Cannot find module '@embedpdf/build')*
- `pnpm --filter @embedpdf/engines lint` *(fails: no-undef, no-unused-vars, etc.)*
- `pnpm --filter @embedpdf/engines build:base` *(fails: Cannot find module '@embedpdf/build')*


------
https://chatgpt.com/codex/tasks/task_e_68b996508030832db515746b58ad21e6