### PR TITLE
refactor measurement overlay rendering

### DIFF
--- a/packages/engines/src/lib/pdfium/engine.ts
+++ b/packages/engines/src/lib/pdfium/engine.ts
@@ -5397,6 +5397,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
     const modified = this.getAnnotationDate(annotationPtr, 'M');
     const created = this.getAnnotationDate(annotationPtr, 'CreationDate');
     const vertices = this.readPdfAnnoVertices(page, annotationPtr);
+    const intent = this.getAnnotIntent(annotationPtr);
     const contents = this.getAnnotString(annotationPtr, 'Contents') || '';
     const flags = this.getAnnotationFlags(annotationPtr);
     const strokeColor = this.getAnnotationColor(annotationPtr);
@@ -5429,6 +5430,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       custom,
       id: index,
       type: PdfAnnotationSubtype.POLYGON,
+      ...(intent && { intent }),
       contents,
       flags,
       strokeColor: strokeColor ?? '#FF0000',
@@ -5469,6 +5471,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
     const contents = this.getAnnotString(annotationPtr, 'Contents') || '';
     const strokeColor = this.getAnnotationColor(annotationPtr);
     const flags = this.getAnnotationFlags(annotationPtr);
+    const intent = this.getAnnotIntent(annotationPtr);
     const interiorColor = this.getAnnotationColor(
       annotationPtr,
       PdfAnnotationColorType.InteriorColor,
@@ -5490,6 +5493,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       custom,
       id: index,
       type: PdfAnnotationSubtype.POLYLINE,
+      ...(intent && { intent }),
       contents,
       flags,
       strokeColor: strokeColor ?? '#FF0000',
@@ -5532,6 +5536,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
     const contents = this.getAnnotString(annotationPtr, 'Contents') || '';
     const strokeColor = this.getAnnotationColor(annotationPtr);
     const flags = this.getAnnotationFlags(annotationPtr);
+    const intent = this.getAnnotIntent(annotationPtr);
     const interiorColor = this.getAnnotationColor(
       annotationPtr,
       PdfAnnotationColorType.InteriorColor,
@@ -5552,6 +5557,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       custom,
       id: index,
       type: PdfAnnotationSubtype.LINE,
+      ...(intent && { intent }),
       flags,
       rect,
       contents,

--- a/packages/models/src/pdf.ts
+++ b/packages/models/src/pdf.ts
@@ -979,6 +979,72 @@ export interface PdfAnnotationObjectBase {
    * Custom data of the annotation
    */
   custom?: any;
+
+  /**
+   * Optional measurement dictionary mirroring Acrobat's `/Measure` entry.
+   *
+   * Consumers that need to persist measurement metadata in PDF files can
+   * serialise this structure into a `/Measure` dictionary when exporting.
+   */
+  measure?: PdfMeasurementDictionary;
+}
+
+/**
+ * Supported measurement value format names for Acrobat measurement dictionaries.
+ *
+ * @public
+ */
+export type PdfMeasurementFormat = 'D' | 'F' | 'R';
+
+/**
+ * Conversion entry describing how a measurement value should be displayed.
+ * Mirrors Acrobat's `/A`, `/D`, and `/X` array item structure.
+ *
+ * @public
+ */
+export interface PdfMeasurementConversion {
+  /** Measurement unit label shown to the user (`/U`). */
+  unit: string;
+
+  /** Conversion factor applied before display (`/C`). */
+  conversionFactor: number;
+
+  /** Precision denominator – typically powers of 10 (`/D`). */
+  precision: number;
+
+  /** Display format (`/F`). */
+  format: PdfMeasurementFormat;
+
+  /** Decimal separator override (`/RD`). */
+  decimalSeparator?: string;
+
+  /** Thousands separator override (`/RT`). */
+  thousandSeparator?: string;
+
+  /** Optional suffix string (`/SS`). */
+  suffix?: string;
+}
+
+/**
+ * Representation of a PDF measurement dictionary (`/Measure`).
+ *
+ * @public
+ */
+export interface PdfMeasurementDictionary {
+  /** Always set to `"Measure"`. */
+  type: 'Measure';
+
+  /** Optional human readable scale string (`/R`). */
+  scale?: string;
+
+  /** Distance conversion entries (stored under `/D`). */
+  distance?: PdfMeasurementConversion[];
+
+  /** Area conversion entries (stored under `/A`). */
+  area?: PdfMeasurementConversion[];
+
+  /** Cross axis conversion entries (stored under `/X`). */
+  cross?: PdfMeasurementConversion[];
 }
 
 /**

--- a/packages/plugin-annotation/src/shared/components/annotations.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations.tsx
@@ -44,6 +44,16 @@ import { Polyline } from './annotations/polyline';
 import { Polygon } from './annotations/polygon';
 import { FreeText } from './annotations/free-text';
 import { Stamp } from './annotations/stamp';
+import { MeasurementLine } from './annotations/measurement-line';
+import { MeasurementPolygon } from './annotations/measurement-polygon';
+
+interface MeasurementCustomPayload {
+  measurement?: {
+    label?: string;
+    labelLines?: string[];
+    kind?: string;
+  };
+}
 
 interface AnnotationsProps {
   pageIndex: number;
@@ -325,16 +335,30 @@ export function Annotations(annotationsProps: AnnotationsProps) {
               }}
               {...annotationsProps}
             >
-              {(obj) => (
-                <Fragment>
-                  <Line
-                    {...obj}
-                    isSelected={isSelected}
-                    scale={scale}
-                    onClick={(e) => handleClick(e, annotation)}
-                  />
-                </Fragment>
-              )}
+              {(obj) => {
+                const measurement = (obj.custom as MeasurementCustomPayload | undefined)?.measurement;
+                const onClick = (
+                  e: MouseEvent<SVGElement> | TouchEvent<SVGElement>,
+                ): void => {
+                  handleClick(e, annotation);
+                };
+                const commonProps = {
+                  ...obj,
+                  isSelected,
+                  scale,
+                  onClick,
+                };
+
+                return (
+                  <Fragment>
+                    {measurement ? (
+                      <MeasurementLine {...commonProps} measurement={measurement} />
+                    ) : (
+                      <Line {...commonProps} />
+                    )}
+                  </Fragment>
+                );
+              }}
             </AnnotationContainer>
           );
         }
@@ -403,16 +427,30 @@ export function Annotations(annotationsProps: AnnotationsProps) {
               }}
               {...annotationsProps}
             >
-              {(obj) => (
-                <Fragment>
-                  <Polygon
-                    {...obj}
-                    isSelected={isSelected}
-                    scale={scale}
-                    onClick={(e) => handleClick(e, annotation)}
-                  />
-                </Fragment>
-              )}
+              {(obj) => {
+                const measurement = (obj.custom as MeasurementCustomPayload | undefined)?.measurement;
+                const onClick = (
+                  e: MouseEvent<SVGElement> | TouchEvent<SVGElement>,
+                ): void => {
+                  handleClick(e, annotation);
+                };
+                const commonProps = {
+                  ...obj,
+                  isSelected,
+                  scale,
+                  onClick,
+                };
+
+                return (
+                  <Fragment>
+                    {measurement ? (
+                      <MeasurementPolygon {...commonProps} measurement={measurement} />
+                    ) : (
+                      <Polygon {...commonProps} />
+                    )}
+                  </Fragment>
+                );
+              }}
             </AnnotationContainer>
           );
         }

--- a/packages/plugin-annotation/src/shared/components/annotations/measurement-label.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/measurement-label.tsx
@@ -1,0 +1,65 @@
+import { JSX } from '@framework';
+
+export interface MeasurementDisplayPayload {
+  label?: string;
+  labelLines?: string[];
+  kind?: string;
+}
+
+export function normaliseMeasurementLines(
+  measurement?: MeasurementDisplayPayload,
+): string[] | undefined {
+  if (!measurement) return undefined;
+  if (measurement.labelLines && measurement.labelLines.length > 0) {
+    return measurement.labelLines;
+  }
+  if (measurement.label) {
+    return [measurement.label];
+  }
+  return undefined;
+}
+
+interface MeasurementLabelProps {
+  lines: string[];
+  position: { x: number; y: number };
+  fontSize: number;
+  strokePadding: number;
+  fill: string;
+  angleDegrees?: number;
+}
+
+export function MeasurementLabel({
+  lines,
+  position,
+  fontSize,
+  strokePadding,
+  fill,
+  angleDegrees,
+}: MeasurementLabelProps): JSX.Element {
+  const rotation =
+    angleDegrees !== undefined
+      ? `rotate(${angleDegrees}, ${position.x}, ${position.y})`
+      : undefined;
+
+  return (
+    <text
+      x={position.x}
+      y={position.y}
+      fontSize={fontSize}
+      textAnchor="middle"
+      dominantBaseline="middle"
+      fill={fill}
+      stroke="#FFFFFF"
+      strokeWidth={strokePadding}
+      paintOrder="stroke"
+      transform={rotation}
+      style={{ pointerEvents: 'none', userSelect: 'none' }}
+    >
+      {lines.map((line, index) => (
+        <tspan key={index} x={position.x} dy={index === 0 ? 0 : fontSize * 1.2}>
+          {line}
+        </tspan>
+      ))}
+    </text>
+  );
+}

--- a/packages/plugin-annotation/src/shared/components/annotations/measurement-line.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/measurement-line.tsx
@@ -1,0 +1,44 @@
+import { JSX } from '@framework';
+
+import { Line, LineProps, LineRenderData } from './line';
+import {
+  MeasurementDisplayPayload,
+  MeasurementLabel,
+  normaliseMeasurementLines,
+} from './measurement-label';
+
+export interface MeasurementLineProps extends Omit<LineProps, 'children'> {
+  measurement?: MeasurementDisplayPayload;
+}
+
+export function MeasurementLine({
+  measurement,
+  strokeWidth,
+  strokeColor = '#000000',
+  ...rest
+}: MeasurementLineProps): JSX.Element {
+  const labelColor = strokeColor !== 'transparent' ? strokeColor : '#000000';
+
+  return (
+    <Line {...rest} strokeWidth={strokeWidth} strokeColor={strokeColor}>
+      {(data: LineRenderData) => {
+        const lines = normaliseMeasurementLines(measurement);
+        if (!lines || lines.length === 0) return null;
+
+        const fontSize = Math.max(10, strokeWidth * 4);
+        const strokePadding = Math.max(0.75, fontSize / 6);
+
+        return (
+          <MeasurementLabel
+            lines={lines}
+            position={{ x: data.midX, y: data.midY }}
+            fontSize={fontSize}
+            strokePadding={strokePadding}
+            fill={labelColor}
+            angleDegrees={data.angleDegrees}
+          />
+        );
+      }}
+    </Line>
+  );
+}

--- a/packages/plugin-annotation/src/shared/components/annotations/measurement-polygon.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/measurement-polygon.tsx
@@ -1,0 +1,82 @@
+import { JSX } from '@framework';
+
+import { Polygon, PolygonProps } from './polygon';
+import {
+  MeasurementDisplayPayload,
+  MeasurementLabel,
+  normaliseMeasurementLines,
+} from './measurement-label';
+
+export interface MeasurementPolygonProps extends Omit<PolygonProps, 'children'> {
+  measurement?: MeasurementDisplayPayload;
+}
+
+function computeCentroid(points: { x: number; y: number }[]): { x: number; y: number } | null {
+  if (points.length === 0) {
+    return null;
+  }
+
+  let area = 0;
+  let centroidX = 0;
+  let centroidY = 0;
+
+  for (let i = 0; i < points.length; i++) {
+    const current = points[i];
+    const next = points[(i + 1) % points.length];
+    const cross = current.x * next.y - next.x * current.y;
+    area += cross;
+    centroidX += (current.x + next.x) * cross;
+    centroidY += (current.y + next.y) * cross;
+  }
+
+  area *= 0.5;
+
+  if (Math.abs(area) < 1e-6) {
+    const sum = points.reduce(
+      (acc, point) => ({ x: acc.x + point.x, y: acc.y + point.y }),
+      { x: 0, y: 0 },
+    );
+    return { x: sum.x / points.length, y: sum.y / points.length };
+  }
+
+  return {
+    x: centroidX / (6 * area),
+    y: centroidY / (6 * area),
+  };
+}
+
+export function MeasurementPolygon({
+  measurement,
+  strokeColor = '#000000',
+  rect,
+  ...rest
+}: MeasurementPolygonProps): JSX.Element {
+  const labelColor = strokeColor !== 'transparent' ? strokeColor : '#000000';
+
+  return (
+    <Polygon {...rest} rect={rect} strokeColor={strokeColor}>
+      {({ localPoints, isPreviewing }) => {
+        if (isPreviewing) return null;
+
+        const lines = normaliseMeasurementLines(measurement);
+        if (!lines || lines.length === 0) return null;
+
+        const centroid = computeCentroid(localPoints);
+        if (!centroid) return null;
+
+        const fontSize = Math.max(10, Math.min(rect.size.width, rect.size.height) * 0.1);
+        const strokePadding = Math.max(0.75, fontSize / 6);
+
+        return (
+          <MeasurementLabel
+            lines={lines}
+            position={centroid}
+            fontSize={fontSize}
+            strokePadding={strokePadding}
+            fill={labelColor}
+          />
+        );
+      }}
+    </Polygon>
+  );
+}

--- a/packages/plugin-annotation/src/shared/components/annotations/polygon.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/polygon.tsx
@@ -1,7 +1,7 @@
-import { useMemo, MouseEvent, TouchEvent } from '@framework';
+import { useMemo, MouseEvent, TouchEvent, JSX } from '@framework';
 import { Rect, Position, PdfAnnotationBorderStyle } from '@embedpdf/models';
 
-interface PolygonProps {
+export interface PolygonProps {
   rect: Rect;
   vertices: Position[];
   color?: string;
@@ -17,23 +17,34 @@ interface PolygonProps {
   // New optional props for preview rendering
   currentVertex?: Position;
   handleSize?: number;
+  custom?: unknown;
+  children?: (data: PolygonRenderData) => JSX.Element | null;
 }
 
-export function Polygon({
-  rect,
-  vertices,
-  color = 'transparent',
-  strokeColor = '#000000',
-  opacity = 1,
-  strokeWidth,
-  strokeStyle = PdfAnnotationBorderStyle.SOLID,
-  strokeDashArray,
-  scale,
-  isSelected,
-  onClick,
-  currentVertex, // A preview-only prop
-  handleSize = 14, // in CSS pixels
-}: PolygonProps): JSX.Element {
+export interface PolygonRenderData {
+  rect: Rect;
+  localPoints: Position[];
+  isPreviewing: boolean;
+  scale: number;
+}
+
+export function Polygon(props: PolygonProps): JSX.Element {
+  const {
+    rect,
+    vertices,
+    color = 'transparent',
+    strokeColor = '#000000',
+    opacity = 1,
+    strokeWidth,
+    strokeStyle = PdfAnnotationBorderStyle.SOLID,
+    strokeDashArray,
+    scale,
+    isSelected,
+    onClick,
+    currentVertex, // A preview-only prop
+    handleSize = 14, // in CSS pixels
+    children,
+  } = props;
   const allPoints = currentVertex ? [...vertices, currentVertex] : vertices;
 
   const localPts = useMemo(
@@ -53,7 +64,7 @@ export function Polygon({
     ).trim();
   }, [localPts, currentVertex]);
 
-  const isPreviewing = currentVertex && vertices.length > 0;
+  const isPreviewing = Boolean(currentVertex && vertices.length > 0);
 
   const width = rect.size.width * scale;
   const height = rect.size.height * scale;
@@ -114,6 +125,8 @@ export function Polygon({
           strokeWidth={strokeWidth / 2}
         />
       )}
+
+      {children?.({ rect, localPoints: localPts, isPreviewing, scale })}
     </svg>
   );
 }

--- a/packages/plugin-measurement/README.md
+++ b/packages/plugin-measurement/README.md
@@ -1,0 +1,3 @@
+# @embedpdf/plugin-measurement
+
+Measurement tools for the EmbedPDF viewer.

--- a/packages/plugin-measurement/package.json
+++ b/packages/plugin-measurement/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@embedpdf/plugin-measurement",
+  "version": "1.3.14",
+  "type": "module",
+  "license": "MIT",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./preact": {
+      "types": "./dist/preact/index.d.ts",
+      "import": "./dist/preact/index.js",
+      "require": "./dist/preact/index.cjs"
+    },
+    "./react": {
+      "types": "./dist/react/index.d.ts",
+      "import": "./dist/react/index.js",
+      "require": "./dist/react/index.cjs"
+    },
+    "./vue": {
+      "types": "./dist/vue/index.d.ts",
+      "import": "./dist/vue/index.js",
+      "require": "./dist/vue/index.cjs"
+    }
+  },
+  "scripts": {
+    "build:base": "vite build --mode base",
+    "build:react": "vite build --mode react",
+    "build:preact": "vite build --mode preact",
+    "build:vue": "vite build --mode vue",
+    "build": "pnpm run clean && concurrently -c auto -n base,react,preact,vue \"vite build --mode base\" \"vite build --mode react\" \"vite build --mode preact\" \"vite build --mode vue\"",
+    "clean": "rimraf dist",
+    "lint": "eslint src --color",
+    "lint:fix": "eslint src --color --fix"
+  },
+  "dependencies": {
+    "@embedpdf/models": "workspace:*"
+  },
+  "devDependencies": {
+    "@embedpdf/build": "workspace:*",
+    "@embedpdf/plugin-annotation": "workspace:*",
+    "typescript": "^5.0.0"
+  },
+  "peerDependencies": {
+    "@embedpdf/core": "workspace:*",
+    "@embedpdf/plugin-annotation": "workspace:*"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embedpdf/embed-pdf-viewer",
+    "directory": "packages/plugin-measurement"
+  },
+  "homepage": "https://www.embedpdf.com/docs",
+  "bugs": {
+    "url": "https://github.com/embedpdf/embed-pdf-viewer/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugin-measurement/src/index.ts
+++ b/packages/plugin-measurement/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib';

--- a/packages/plugin-measurement/src/lib/index.ts
+++ b/packages/plugin-measurement/src/lib/index.ts
@@ -1,0 +1,18 @@
+import { PluginPackage } from '@embedpdf/core';
+
+import { manifest, MEASUREMENT_PLUGIN_ID } from './manifest';
+import { MeasurementPlugin } from './measurement-plugin';
+import { MeasurementCapability, MeasurementPluginConfig } from './types';
+
+export const MeasurementPluginPackage: PluginPackage<
+  MeasurementPlugin,
+  MeasurementPluginConfig,
+  MeasurementCapability
+> = {
+  manifest,
+  create: (registry, config) => new MeasurementPlugin(MEASUREMENT_PLUGIN_ID, registry, config),
+};
+
+export * from './measurement-plugin';
+export * from './types';
+export * from './manifest';

--- a/packages/plugin-measurement/src/lib/manifest.ts
+++ b/packages/plugin-measurement/src/lib/manifest.ts
@@ -1,0 +1,20 @@
+import { PluginManifest } from '@embedpdf/core';
+
+import { MeasurementPluginConfig } from './types';
+
+export const MEASUREMENT_PLUGIN_ID = 'measurement' as const;
+
+export const manifest: PluginManifest<MeasurementPluginConfig> = {
+  id: MEASUREMENT_PLUGIN_ID,
+  name: 'Measurement Plugin',
+  version: '1.0.0',
+  provides: ['measurement'],
+  requires: ['annotation'],
+  optional: [],
+  defaultConfig: {
+    enabled: true,
+    unit: 'in',
+    precision: 2,
+    pointsPerUnit: 72,
+  },
+};

--- a/packages/plugin-measurement/src/lib/measurement-plugin.ts
+++ b/packages/plugin-measurement/src/lib/measurement-plugin.ts
@@ -14,6 +14,7 @@ import {
   AnnotationEvent,
 } from '@embedpdf/plugin-annotation';
 
+import { buildPdfMeasureDictionary } from './pdf-measure';
 import {
   CalibrationRequest,
   MeasurementCapability,
@@ -369,6 +370,7 @@ export class MeasurementPlugin extends BasePlugin<MeasurementPluginConfig, Measu
         this.annotation.updateAnnotation(pageIndex, annotation.id, {
           custom: newCustom,
           contents: '',
+          measure: undefined,
         });
       }
       return;
@@ -389,6 +391,7 @@ export class MeasurementPlugin extends BasePlugin<MeasurementPluginConfig, Measu
     this.annotation.updateAnnotation(pageIndex, annotation.id, {
       custom: newCustom,
       contents: measurement.label,
+      measure: measurement.pdfMeasure,
     });
   }
 
@@ -534,6 +537,7 @@ export class MeasurementPlugin extends BasePlugin<MeasurementPluginConfig, Measu
         unit,
         formatted,
       },
+      pdfMeasure: this.buildPdfMeasure('distance'),
       lastUpdated: new Date().toISOString(),
     };
 
@@ -579,6 +583,7 @@ export class MeasurementPlugin extends BasePlugin<MeasurementPluginConfig, Measu
         unit: perimeterUnit,
         formatted: perimeterFormatted,
       },
+      pdfMeasure: this.buildPdfMeasure('area'),
       lastUpdated: new Date().toISOString(),
     };
 
@@ -610,6 +615,7 @@ export class MeasurementPlugin extends BasePlugin<MeasurementPluginConfig, Measu
         unit: perimeterUnit,
         formatted: perimeterFormatted,
       },
+      pdfMeasure: this.buildPdfMeasure('perimeter'),
       lastUpdated: new Date().toISOString(),
     };
 
@@ -693,6 +699,15 @@ export class MeasurementPlugin extends BasePlugin<MeasurementPluginConfig, Measu
       case 'perimeter':
         return this.formatPerimeter(value, unit, ctx);
     }
+  }
+
+  private buildPdfMeasure(kind: Exclude<MeasurementKind, 'calibration'>) {
+    return buildPdfMeasureDictionary({
+      unit: this.state.unit,
+      pointsPerUnit: this.state.pointsPerUnit,
+      precision: this.state.precision,
+      kind,
+    });
   }
 
   private defaultFormat(value: number, unit: string): string {

--- a/packages/plugin-measurement/src/lib/measurement-plugin.ts
+++ b/packages/plugin-measurement/src/lib/measurement-plugin.ts
@@ -1,0 +1,705 @@
+import { BasePlugin, PluginRegistry, createBehaviorEmitter } from '@embedpdf/core';
+import {
+  ignore,
+  PdfAnnotationObject,
+  PdfAnnotationSubtype,
+  PdfAnnotationLineEnding,
+  PdfLineAnnoObject,
+  PdfPolygonAnnoObject,
+} from '@embedpdf/models';
+import {
+  AnnotationCapability,
+  AnnotationPlugin,
+  AnnotationTool,
+  AnnotationEvent,
+} from '@embedpdf/plugin-annotation';
+
+import {
+  CalibrationRequest,
+  MeasurementCapability,
+  MeasurementDisplayData,
+  MeasurementKind,
+  MeasurementPluginConfig,
+  MeasurementState,
+  MeasurementFormatContext,
+} from './types';
+
+interface MeasurementAnnotationCustom {
+  measurement?: MeasurementDisplayData;
+  [key: string]: unknown;
+}
+
+export class MeasurementPlugin extends BasePlugin<MeasurementPluginConfig, MeasurementCapability> {
+  static readonly id = 'measurement' as const;
+
+  private readonly state$ = createBehaviorEmitter<MeasurementState>();
+  private readonly config: MeasurementPluginConfig;
+  private state: MeasurementState;
+  private annotation: AnnotationCapability | null;
+  private unsubscribeAnnotation?: () => void;
+
+  constructor(id: string, registry: PluginRegistry, config: MeasurementPluginConfig) {
+    super(id, registry);
+
+    this.config = config;
+    this.annotation = registry.getPlugin<AnnotationPlugin>('annotation')?.provides() ?? null;
+
+    const precision = Math.max(0, config.precision ?? 2);
+    const pointsPerUnit = this.normalisePointsPerUnit(config.pointsPerUnit ?? 72);
+
+    this.state = {
+      enabled: config.enabled ?? true,
+      unit: config.unit ?? 'in',
+      precision,
+      pointsPerUnit,
+      lastCalibration: undefined,
+    };
+  }
+
+  async initialize(): Promise<void> {
+    if (!this.state.enabled) return;
+
+    if (!this.annotation) {
+      this.logger.warn(
+        'MeasurementPlugin',
+        'MissingDependency',
+        'Annotation plugin is required for measurement tools.',
+      );
+      return;
+    }
+
+    this.registerMeasurementTools();
+    this.unsubscribeAnnotation = this.annotation.onAnnotationEvent((event) =>
+      this.handleAnnotationEvent(event),
+    );
+
+    // Process existing annotations if a document is already loaded
+    if (this.coreState.core.document) {
+      this.recalculateAll();
+    }
+  }
+
+  async destroy(): Promise<void> {
+    this.unsubscribeAnnotation?.();
+    await super.destroy();
+  }
+
+  protected buildCapability(): MeasurementCapability {
+    return {
+      getState: () => this.state,
+      onStateChange: this.state$.on,
+      setUnit: (unit: string) => {
+        if (!unit || unit === this.state.unit) return;
+        this.setState({ unit });
+        this.recalculateAll();
+      },
+      setPrecision: (precision: number) => {
+        const next = Math.max(0, precision);
+        if (next === this.state.precision) return;
+        this.setState({ precision: next });
+        this.recalculateAll();
+      },
+      setPointsPerUnit: (ppu: number) => {
+        const next = this.normalisePointsPerUnit(ppu);
+        if (next === this.state.pointsPerUnit) return;
+        this.setState({ pointsPerUnit: next });
+        this.recalculateAll();
+      },
+      formatDistance: (value: number, unit?: string) =>
+        this.formatValue(value, unit ?? this.state.unit, 'distance'),
+      formatArea: (value: number, unit?: string) =>
+        this.formatValue(value, unit ?? this.areaUnit(this.state.unit), 'area'),
+      formatPerimeter: (value: number, unit?: string) =>
+        this.formatValue(value, unit ?? this.state.unit, 'perimeter'),
+      recalculateAll: () => this.recalculateAll(),
+    };
+  }
+
+  private setState(patch: Partial<MeasurementState>) {
+    this.state = { ...this.state, ...patch };
+    this.state$.emit(this.state);
+  }
+
+  private normalisePointsPerUnit(value: number): number {
+    if (!Number.isFinite(value) || value <= 0) {
+      return 72; // Default to points-per-inch
+    }
+    return value;
+  }
+
+  private registerMeasurementTools() {
+    if (!this.annotation) return;
+
+    const tools = this.annotation.getTools();
+    const existing = new Set(tools.map((tool) => tool.id));
+
+    const toRegister: AnnotationTool[] = [];
+
+    if (!existing.has('manualCalibration')) {
+      toRegister.push(this.createManualCalibrationTool());
+    }
+    if (!existing.has('measureDistance')) {
+      toRegister.push(this.createDistanceTool());
+    }
+    if (!existing.has('measureArea')) {
+      toRegister.push(this.createAreaTool());
+    }
+    if (!existing.has('measurePerimeter')) {
+      toRegister.push(this.createPerimeterTool());
+    }
+
+    toRegister.forEach((tool) => this.annotation?.addTool(tool));
+  }
+
+  private createManualCalibrationTool(): AnnotationTool<PdfLineAnnoObject> {
+    return {
+      id: 'manualCalibration',
+      name: 'Calibrate',
+      matchScore: (annotation) => {
+        const kind = this.getCustomMeasurementKind(annotation);
+        if (annotation.type === PdfAnnotationSubtype.LINE && kind === 'calibration') {
+          return 100;
+        }
+        return 0;
+      },
+      interaction: {
+        exclusive: false,
+        cursor: 'crosshair',
+        isDraggable: false,
+        isResizable: false,
+        lockAspectRatio: false,
+      },
+      defaults: {
+        type: PdfAnnotationSubtype.LINE,
+        intent: 'LineDimension',
+        color: 'transparent',
+        opacity: 1,
+        strokeWidth: 2,
+        strokeColor: '#2E7D32',
+        lineEndings: {
+          start: PdfAnnotationLineEnding.None,
+          end: PdfAnnotationLineEnding.None,
+        },
+        custom: {
+          measurement: {
+            kind: 'calibration',
+          },
+        } as MeasurementAnnotationCustom,
+      },
+      behavior: {
+        deactivateToolAfterCreate: true,
+      },
+    };
+  }
+
+  private createDistanceTool(): AnnotationTool<PdfLineAnnoObject> {
+    return {
+      id: 'measureDistance',
+      name: 'Distance',
+      matchScore: (annotation) => {
+        if (annotation.type !== PdfAnnotationSubtype.LINE) return 0;
+        const kind = this.getCustomMeasurementKind(annotation);
+        if (kind === 'calibration') return 0;
+        return annotation.intent === 'LineDimension' ? 90 : 0;
+      },
+      interaction: {
+        exclusive: false,
+        cursor: 'crosshair',
+        isDraggable: true,
+        isResizable: false,
+        lockAspectRatio: false,
+      },
+      defaults: {
+        type: PdfAnnotationSubtype.LINE,
+        intent: 'LineDimension',
+        color: 'transparent',
+        opacity: 1,
+        strokeWidth: 2,
+        strokeColor: '#1E88E5',
+        lineEndings: {
+          start: PdfAnnotationLineEnding.None,
+          end: PdfAnnotationLineEnding.None,
+        },
+        custom: {
+          measurement: {
+            kind: 'distance',
+          },
+        } as MeasurementAnnotationCustom,
+      },
+      clickBehavior: {
+        enabled: true,
+        defaultLength: 100,
+        defaultAngle: 0,
+      },
+    };
+  }
+
+  private createAreaTool(): AnnotationTool<PdfPolygonAnnoObject> {
+    return {
+      id: 'measureArea',
+      name: 'Area',
+      matchScore: (annotation) => {
+        if (annotation.type !== PdfAnnotationSubtype.POLYGON) return 0;
+        const kind = this.getCustomMeasurementKind(annotation);
+        if (kind && kind !== 'area') return 0;
+        return annotation.intent === 'PolygonDimension' ? 80 : 0;
+      },
+      interaction: {
+        exclusive: false,
+        cursor: 'crosshair',
+        isDraggable: true,
+        isResizable: false,
+        lockAspectRatio: false,
+      },
+      defaults: {
+        type: PdfAnnotationSubtype.POLYGON,
+        intent: 'PolygonDimension',
+        color: '#1E88E5',
+        opacity: 0.15,
+        strokeWidth: 2,
+        strokeColor: '#1565C0',
+        custom: {
+          measurement: {
+            kind: 'area',
+          },
+        } as MeasurementAnnotationCustom,
+      },
+    };
+  }
+
+  private createPerimeterTool(): AnnotationTool<PdfPolygonAnnoObject> {
+    return {
+      id: 'measurePerimeter',
+      name: 'Perimeter',
+      matchScore: (annotation) => {
+        if (annotation.type !== PdfAnnotationSubtype.POLYGON) return 0;
+        const kind = this.getCustomMeasurementKind(annotation);
+        return kind === 'perimeter' ? 90 : 0;
+      },
+      interaction: {
+        exclusive: false,
+        cursor: 'crosshair',
+        isDraggable: true,
+        isResizable: false,
+        lockAspectRatio: false,
+      },
+      defaults: {
+        type: PdfAnnotationSubtype.POLYGON,
+        intent: 'PolygonDimension',
+        color: 'transparent',
+        opacity: 1,
+        strokeWidth: 2,
+        strokeColor: '#F4511E',
+        custom: {
+          measurement: {
+            kind: 'perimeter',
+          },
+        } as MeasurementAnnotationCustom,
+      },
+    };
+  }
+
+  private handleAnnotationEvent(event: AnnotationEvent) {
+    if (!this.state.enabled || !this.annotation) return;
+
+    switch (event.type) {
+      case 'create':
+        this.processAnnotation(event.annotation, event.pageIndex);
+        break;
+      case 'update': {
+        const merged: PdfAnnotationObject = {
+          ...event.annotation,
+          ...event.patch,
+        } as PdfAnnotationObject;
+        this.processAnnotation(merged, event.pageIndex);
+        break;
+      }
+      case 'loaded':
+        this.recalculateAll();
+        break;
+      default:
+        break;
+    }
+  }
+
+  private processAnnotation(annotation: PdfAnnotationObject, pageIndex: number) {
+    const kind = this.resolveMeasurementKind(annotation);
+    if (!kind) return;
+
+    if (kind === 'calibration' && annotation.type === PdfAnnotationSubtype.LINE) {
+      this.handleCalibration(pageIndex, annotation as PdfLineAnnoObject);
+      return;
+    }
+
+    if (kind === 'distance' && annotation.type === PdfAnnotationSubtype.LINE) {
+      const measurement = this.computeDistanceMeasurement(annotation as PdfLineAnnoObject);
+      this.applyMeasurementResult(pageIndex, annotation, measurement);
+      return;
+    }
+
+    if (annotation.type === PdfAnnotationSubtype.POLYGON) {
+      if (kind === 'area') {
+        const measurement = this.computeAreaMeasurement(annotation as PdfPolygonAnnoObject);
+        this.applyMeasurementResult(pageIndex, annotation, measurement);
+        return;
+      }
+      if (kind === 'perimeter') {
+        const measurement = this.computePerimeterMeasurement(annotation as PdfPolygonAnnoObject);
+        this.applyMeasurementResult(pageIndex, annotation, measurement);
+        return;
+      }
+    }
+  }
+
+  private applyMeasurementResult(
+    pageIndex: number,
+    annotation: PdfAnnotationObject,
+    measurement: MeasurementDisplayData | null,
+  ) {
+    if (!this.annotation) return;
+
+    const existingCustom = (annotation.custom ?? {}) as MeasurementAnnotationCustom;
+    const currentMeasurement = existingCustom.measurement;
+
+    if (!measurement) {
+      if (currentMeasurement) {
+        const restCustom: MeasurementAnnotationCustom = { ...existingCustom };
+        delete restCustom.measurement;
+        const newCustom = Object.keys(restCustom).length > 0 ? restCustom : undefined;
+        this.annotation.updateAnnotation(pageIndex, annotation.id, {
+          custom: newCustom,
+          contents: '',
+        });
+      }
+      return;
+    }
+
+    const labelsMatch = annotation.contents === measurement.label;
+    const measurementUnchanged = this.areMeasurementsEqual(currentMeasurement, measurement);
+
+    if (measurementUnchanged && labelsMatch) {
+      return;
+    }
+
+    const newCustom: MeasurementAnnotationCustom = {
+      ...existingCustom,
+      measurement,
+    };
+
+    this.annotation.updateAnnotation(pageIndex, annotation.id, {
+      custom: newCustom,
+      contents: measurement.label,
+    });
+  }
+
+  private areMeasurementsEqual(a?: MeasurementDisplayData, b?: MeasurementDisplayData): boolean {
+    if (!a && !b) return true;
+    if (!a || !b) return false;
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+
+  private handleCalibration(pageIndex: number, annotation: PdfLineAnnoObject) {
+    const pdfDistance = this.measureLineLength(annotation);
+    if (pdfDistance <= 0) {
+      this.annotation?.deleteAnnotation(pageIndex, annotation.id);
+      return;
+    }
+
+    const request: CalibrationRequest = {
+      pageIndex,
+      annotation,
+      pdfDistance,
+      unit: this.state.unit,
+      pointsPerUnit: this.state.pointsPerUnit,
+    };
+
+    const responder =
+      this.config.onCalibrationRequest ??
+      ((req: CalibrationRequest) => this.promptForCalibration(req));
+
+    Promise.resolve(responder(request))
+      .then((actual) => {
+        if (!actual || !Number.isFinite(actual) || actual <= 0) return;
+        const pointsPerUnit = pdfDistance / actual;
+        const nextScale = this.normalisePointsPerUnit(pointsPerUnit);
+
+        this.setState({
+          pointsPerUnit: nextScale,
+          lastCalibration: {
+            pageIndex,
+            pdfDistance,
+            actualDistance: actual,
+            unit: this.state.unit,
+            timestamp: new Date().toISOString(),
+          },
+        });
+        this.recalculateAll();
+      })
+      .finally(() => {
+        // Ensure the calibration line does not persist even if calibration was cancelled
+        this.annotation?.deleteAnnotation(pageIndex, annotation.id);
+      })
+      .catch((error) => {
+        this.logger.warn('MeasurementPlugin', 'CalibrationFailed', String(error));
+      });
+  }
+
+  private promptForCalibration(request: CalibrationRequest): number | null {
+    const promptValue =
+      typeof globalThis === 'object' && globalThis !== null && 'prompt' in globalThis
+        ? (globalThis as { prompt?: unknown }).prompt
+        : undefined;
+
+    if (typeof promptValue !== 'function') {
+      return null;
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    const promptFn = promptValue as (..._parameters: [string, string?]) => string | null;
+
+    const current = this.formatValue(
+      request.pdfDistance / this.state.pointsPerUnit,
+      this.state.unit,
+      'distance',
+      { annotation: request.annotation, kind: 'distance' },
+    );
+
+    const input = promptFn(
+      `Enter the actual distance (${this.state.unit}) for the reference line.\n` +
+        `Current scale distance: ${current}`,
+    );
+    if (!input) return null;
+    const parsed = Number.parseFloat(input);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }
+
+  private recalculateAll() {
+    if (!this.annotation) return;
+
+    const document = this.coreState.core.document;
+    if (!document) return;
+
+    for (const page of document.pages) {
+      this.annotation.getPageAnnotations({ pageIndex: page.index }).wait((annotations) => {
+        annotations.forEach((annotation) => this.processAnnotation(annotation, page.index));
+      }, ignore);
+    }
+  }
+
+  private resolveMeasurementKind(annotation: PdfAnnotationObject): MeasurementKind | null {
+    const customKind = this.getCustomMeasurementKind(annotation);
+    if (customKind) return customKind;
+
+    if (annotation.type === PdfAnnotationSubtype.LINE && annotation.intent === 'LineDimension') {
+      return 'distance';
+    }
+
+    if (
+      annotation.type === PdfAnnotationSubtype.POLYGON &&
+      annotation.intent === 'PolygonDimension'
+    ) {
+      return 'area';
+    }
+
+    return null;
+  }
+
+  private getCustomMeasurementKind(annotation: PdfAnnotationObject): MeasurementKind | undefined {
+    const custom = annotation.custom as MeasurementAnnotationCustom | undefined;
+    const kind = custom?.measurement?.kind;
+    if (kind === 'distance' || kind === 'area' || kind === 'perimeter' || kind === 'calibration') {
+      return kind;
+    }
+    return undefined;
+  }
+
+  private computeDistanceMeasurement(annotation: PdfLineAnnoObject): MeasurementDisplayData | null {
+    const pdfLength = this.measureLineLength(annotation);
+    if (pdfLength <= 0) return null;
+
+    const value = pdfLength / this.state.pointsPerUnit;
+    const unit = this.state.unit;
+
+    const context: MeasurementFormatContext = { annotation, kind: 'distance' };
+    const formatted = this.formatDistance(value, unit, context);
+
+    const measurement: MeasurementDisplayData = {
+      kind: 'distance',
+      scale: this.getScale(),
+      label: `Distance: ${formatted}`,
+      labelLines: [`Distance: ${formatted}`],
+      distance: {
+        raw: pdfLength,
+        value,
+        unit,
+        formatted,
+      },
+      lastUpdated: new Date().toISOString(),
+    };
+
+    return measurement;
+  }
+
+  private computeAreaMeasurement(annotation: PdfPolygonAnnoObject): MeasurementDisplayData | null {
+    if (annotation.vertices.length < 3) return null;
+
+    const pdfArea = this.measurePolygonArea(annotation.vertices);
+    const pdfPerimeter = this.measurePolygonPerimeter(annotation.vertices);
+    if (pdfArea <= 0 || pdfPerimeter <= 0) return null;
+
+    const areaValue = pdfArea / (this.state.pointsPerUnit * this.state.pointsPerUnit);
+    const perimeterValue = pdfPerimeter / this.state.pointsPerUnit;
+
+    const areaUnit = this.areaUnit(this.state.unit);
+    const perimeterUnit = this.state.unit;
+
+    const context: MeasurementFormatContext = { annotation, kind: 'area' };
+    const areaFormatted = this.formatArea(areaValue, areaUnit, context);
+    const perimeterFormatted = this.formatPerimeter(perimeterValue, perimeterUnit, {
+      annotation,
+      kind: 'perimeter',
+    });
+
+    const labelLines = [`Area: ${areaFormatted}`, `Perimeter: ${perimeterFormatted}`];
+
+    const measurement: MeasurementDisplayData = {
+      kind: 'area',
+      scale: this.getScale(),
+      label: labelLines.join(' · '),
+      labelLines,
+      area: {
+        raw: pdfArea,
+        value: areaValue,
+        unit: areaUnit,
+        formatted: areaFormatted,
+      },
+      perimeter: {
+        raw: pdfPerimeter,
+        value: perimeterValue,
+        unit: perimeterUnit,
+        formatted: perimeterFormatted,
+      },
+      lastUpdated: new Date().toISOString(),
+    };
+
+    return measurement;
+  }
+
+  private computePerimeterMeasurement(
+    annotation: PdfPolygonAnnoObject,
+  ): MeasurementDisplayData | null {
+    if (annotation.vertices.length < 2) return null;
+
+    const pdfPerimeter = this.measurePolygonPerimeter(annotation.vertices);
+    if (pdfPerimeter <= 0) return null;
+
+    const perimeterValue = pdfPerimeter / this.state.pointsPerUnit;
+    const perimeterUnit = this.state.unit;
+
+    const context: MeasurementFormatContext = { annotation, kind: 'perimeter' };
+    const perimeterFormatted = this.formatPerimeter(perimeterValue, perimeterUnit, context);
+
+    const measurement: MeasurementDisplayData = {
+      kind: 'perimeter',
+      scale: this.getScale(),
+      label: `Perimeter: ${perimeterFormatted}`,
+      labelLines: [`Perimeter: ${perimeterFormatted}`],
+      perimeter: {
+        raw: pdfPerimeter,
+        value: perimeterValue,
+        unit: perimeterUnit,
+        formatted: perimeterFormatted,
+      },
+      lastUpdated: new Date().toISOString(),
+    };
+
+    return measurement;
+  }
+
+  private getScale() {
+    return {
+      unit: this.state.unit,
+      pointsPerUnit: this.state.pointsPerUnit,
+      precision: this.state.precision,
+    };
+  }
+
+  private measureLineLength(annotation: PdfLineAnnoObject): number {
+    const { start, end } = annotation.linePoints;
+    const dx = end.x - start.x;
+    const dy = end.y - start.y;
+    return Math.hypot(dx, dy);
+  }
+
+  private measurePolygonPerimeter(vertices: { x: number; y: number }[]): number {
+    if (vertices.length < 2) return 0;
+    let sum = 0;
+    for (let i = 0; i < vertices.length; i++) {
+      const current = vertices[i];
+      const next = vertices[(i + 1) % vertices.length];
+      sum += Math.hypot(next.x - current.x, next.y - current.y);
+    }
+    return sum;
+  }
+
+  private measurePolygonArea(vertices: { x: number; y: number }[]): number {
+    let area = 0;
+    for (let i = 0; i < vertices.length; i++) {
+      const current = vertices[i];
+      const next = vertices[(i + 1) % vertices.length];
+      area += current.x * next.y - next.x * current.y;
+    }
+    return Math.abs(area) / 2;
+  }
+
+  private areaUnit(unit: string): string {
+    return `${unit}\u00B2`;
+  }
+
+  private formatDistance(value: number, unit: string, ctx: MeasurementFormatContext): string {
+    if (this.config.formatDistance) {
+      return this.config.formatDistance(value, unit, ctx);
+    }
+    return this.defaultFormat(value, unit);
+  }
+
+  private formatArea(value: number, unit: string, ctx: MeasurementFormatContext): string {
+    if (this.config.formatArea) {
+      return this.config.formatArea(value, unit, ctx);
+    }
+    return this.defaultFormat(value, unit);
+  }
+
+  private formatPerimeter(value: number, unit: string, ctx: MeasurementFormatContext): string {
+    if (this.config.formatPerimeter) {
+      return this.config.formatPerimeter(value, unit, ctx);
+    }
+    return this.defaultFormat(value, unit);
+  }
+
+  private formatValue(
+    value: number,
+    unit: string,
+    kind: Exclude<MeasurementKind, 'calibration'>,
+    context?: MeasurementFormatContext,
+  ): string {
+    const ctx: MeasurementFormatContext = context ?? { annotation: null, kind };
+
+    switch (kind) {
+      case 'distance':
+        return this.formatDistance(value, unit, ctx);
+      case 'area':
+        return this.formatArea(value, unit, ctx);
+      case 'perimeter':
+        return this.formatPerimeter(value, unit, ctx);
+    }
+  }
+
+  private defaultFormat(value: number, unit: string): string {
+    const formatted = value.toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: this.state.precision,
+    });
+    return `${formatted} ${unit}`.trim();
+  }
+}

--- a/packages/plugin-measurement/src/lib/pdf-measure.ts
+++ b/packages/plugin-measurement/src/lib/pdf-measure.ts
@@ -1,0 +1,133 @@
+import { PdfMeasurementConversion, PdfMeasurementDictionary } from '@embedpdf/models';
+
+import { MeasurementKind } from './types';
+
+interface PdfMeasureOptions {
+  unit: string;
+  pointsPerUnit: number;
+  precision: number;
+  kind: Exclude<MeasurementKind, 'calibration'>;
+}
+
+interface NumberSeparators {
+  decimal: string;
+  thousands?: string;
+}
+
+function squaredUnit(unit: string): string {
+  return `${unit}\u00B2`;
+}
+
+function getNumberSeparators(): NumberSeparators {
+  const formatter = new Intl.NumberFormat(undefined, {
+    useGrouping: true,
+    maximumFractionDigits: 2,
+  });
+
+  const decimalPart = formatter.formatToParts(1.1).find((part) => part.type === 'decimal');
+  const groupPart = formatter.formatToParts(1000).find((part) => part.type === 'group');
+
+  return {
+    decimal: decimalPart?.value ?? '.',
+    thousands: groupPart?.value,
+  };
+}
+
+function formatRatio(value: number, precision: number): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: precision,
+  });
+}
+
+const DEFAULT_POINTS_PER_UNIT: Record<string, number> = {
+  in: 72,
+  inch: 72,
+  inches: 72,
+  ft: 72 * 12,
+  foot: 72 * 12,
+  feet: 72 * 12,
+  yd: 72 * 36,
+  yard: 72 * 36,
+  yards: 72 * 36,
+  mi: 72 * 63360,
+  mile: 72 * 63360,
+  miles: 72 * 63360,
+  pt: 1,
+  mm: 72 / 25.4,
+  millimeter: 72 / 25.4,
+  millimeters: 72 / 25.4,
+  cm: 72 / 2.54,
+  centimetre: 72 / 2.54,
+  centimetres: 72 / 2.54,
+  centimeter: 72 / 2.54,
+  centimeters: 72 / 2.54,
+  m: 72 / 0.0254,
+  metre: 72 / 0.0254,
+  metres: 72 / 0.0254,
+  meter: 72 / 0.0254,
+  meters: 72 / 0.0254,
+};
+
+function getScaleString(
+  unit: string,
+  pointsPerUnit: number,
+  precision: number,
+): string | undefined {
+  if (!pointsPerUnit || !Number.isFinite(pointsPerUnit)) {
+    return undefined;
+  }
+
+  const baseline = DEFAULT_POINTS_PER_UNIT[unit.toLowerCase()] ?? pointsPerUnit;
+  const ratio = pointsPerUnit / baseline;
+
+  return `1 ${unit} = ${formatRatio(ratio, precision)} ${unit}`;
+}
+
+function createConversion(
+  unit: string,
+  conversionFactor: number,
+  precision: number,
+  separators: NumberSeparators,
+): PdfMeasurementConversion {
+  return {
+    unit,
+    conversionFactor,
+    precision: Math.pow(10, precision),
+    format: 'D',
+    decimalSeparator: separators.decimal,
+    thousandSeparator: separators.thousands,
+  };
+}
+
+export function buildPdfMeasureDictionary({
+  unit,
+  pointsPerUnit,
+  precision,
+  kind,
+}: PdfMeasureOptions): PdfMeasurementDictionary {
+  const separators = getNumberSeparators();
+  const scale = getScaleString(unit, pointsPerUnit, precision);
+
+  const distanceConversion = createConversion(unit, 1, precision, separators);
+  const crossConversion = createConversion(
+    unit,
+    pointsPerUnit ? 1 / pointsPerUnit : 0,
+    precision,
+    separators,
+  );
+
+  const measure: PdfMeasurementDictionary = {
+    type: 'Measure',
+    scale,
+    distance: [distanceConversion],
+    cross: [crossConversion],
+  };
+
+  if (kind === 'area') {
+    const areaConversion = createConversion(squaredUnit(unit), 1, precision, separators);
+    measure.area = [areaConversion];
+  }
+
+  return measure;
+}

--- a/packages/plugin-measurement/src/lib/types.ts
+++ b/packages/plugin-measurement/src/lib/types.ts
@@ -1,5 +1,9 @@
 import { BasePluginConfig, EventHook } from '@embedpdf/core';
-import { PdfLineAnnoObject, PdfPolygonAnnoObject } from '@embedpdf/models';
+import {
+  PdfLineAnnoObject,
+  PdfMeasurementDictionary,
+  PdfPolygonAnnoObject,
+} from '@embedpdf/models';
 
 export type MeasurementKind = 'distance' | 'area' | 'perimeter' | 'calibration';
 
@@ -28,6 +32,7 @@ export interface MeasurementDisplayData {
   distance?: MeasurementValue;
   area?: MeasurementValue;
   perimeter?: MeasurementValue;
+  pdfMeasure?: PdfMeasurementDictionary;
   lastUpdated: string;
 }
 

--- a/packages/plugin-measurement/src/lib/types.ts
+++ b/packages/plugin-measurement/src/lib/types.ts
@@ -1,0 +1,86 @@
+import { BasePluginConfig, EventHook } from '@embedpdf/core';
+import { PdfLineAnnoObject, PdfPolygonAnnoObject } from '@embedpdf/models';
+
+export type MeasurementKind = 'distance' | 'area' | 'perimeter' | 'calibration';
+
+export interface MeasurementValue {
+  /** Raw measurement in PDF units (or squared PDF units). */
+  raw: number;
+  /** Measurement converted to the configured unit. */
+  value: number;
+  /** Unit label used for the formatted string. */
+  unit: string;
+  /** Formatted display string. */
+  formatted: string;
+}
+
+export interface MeasurementScale {
+  unit: string;
+  pointsPerUnit: number;
+  precision: number;
+}
+
+export interface MeasurementDisplayData {
+  kind: MeasurementKind;
+  scale: MeasurementScale;
+  label: string;
+  labelLines: string[];
+  distance?: MeasurementValue;
+  area?: MeasurementValue;
+  perimeter?: MeasurementValue;
+  lastUpdated: string;
+}
+
+export interface CalibrationRecord {
+  pageIndex: number;
+  pdfDistance: number;
+  actualDistance: number;
+  unit: string;
+  timestamp: string;
+}
+
+export interface MeasurementState {
+  enabled: boolean;
+  unit: string;
+  precision: number;
+  pointsPerUnit: number;
+  lastCalibration?: CalibrationRecord;
+}
+
+export interface MeasurementFormatContext {
+  annotation: PdfLineAnnoObject | PdfPolygonAnnoObject | null;
+  kind: Exclude<MeasurementKind, 'calibration'>;
+}
+
+export interface CalibrationRequest {
+  pageIndex: number;
+  annotation: PdfLineAnnoObject;
+  pdfDistance: number;
+  unit: string;
+  pointsPerUnit: number;
+}
+
+export interface MeasurementPluginConfig extends BasePluginConfig {
+  unit?: string;
+  precision?: number;
+  /**
+   * Number of PDF points that equal one display unit. Defaults to 72 (1 inch).
+   */
+  pointsPerUnit?: number;
+  formatDistance?: (value: number, unit: string, ctx: MeasurementFormatContext) => string;
+  formatArea?: (value: number, unit: string, ctx: MeasurementFormatContext) => string;
+  formatPerimeter?: (value: number, unit: string, ctx: MeasurementFormatContext) => string;
+  onCalibrationRequest?: (request: CalibrationRequest) => number | null | Promise<number | null>;
+}
+
+export interface MeasurementCapability {
+  getState(): MeasurementState;
+  onStateChange: EventHook<MeasurementState>;
+  setUnit(unit: string): void;
+  setPrecision(precision: number): void;
+  setPointsPerUnit(pointsPerUnit: number): void;
+  formatDistance(value: number, unit?: string): string;
+  formatArea(value: number, unit?: string): string;
+  formatPerimeter(value: number, unit?: string): string;
+  recalculateAll(): void;
+}

--- a/packages/plugin-measurement/src/preact/index.ts
+++ b/packages/plugin-measurement/src/preact/index.ts
@@ -1,0 +1,1 @@
+export * from '../shared';

--- a/packages/plugin-measurement/src/react/index.ts
+++ b/packages/plugin-measurement/src/react/index.ts
@@ -1,0 +1,1 @@
+export * from '../shared';

--- a/packages/plugin-measurement/src/shared/index.ts
+++ b/packages/plugin-measurement/src/shared/index.ts
@@ -1,0 +1,1 @@
+export * from '../lib';

--- a/packages/plugin-measurement/src/vue/index.ts
+++ b/packages/plugin-measurement/src/vue/index.ts
@@ -1,0 +1,1 @@
+export * from '../shared';

--- a/packages/plugin-measurement/tsconfig.json
+++ b/packages/plugin-measurement/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {
+      "@embedpdf/plugin-measurement": ["./src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/plugin-measurement/vite.config.ts
+++ b/packages/plugin-measurement/vite.config.ts
@@ -1,0 +1,2 @@
+import { defineLibrary } from '@embedpdf/build/vite';
+export default defineLibrary();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -987,6 +987,25 @@ importers:
         specifier: ^5.0.0
         version: 5.8.2
 
+  packages/plugin-measurement:
+    dependencies:
+      '@embedpdf/core':
+        specifier: workspace:*
+        version: link:../core
+      '@embedpdf/models':
+        specifier: workspace:*
+        version: link:../models
+    devDependencies:
+      '@embedpdf/build':
+        specifier: workspace:*
+        version: link:../build
+      '@embedpdf/plugin-annotation':
+        specifier: workspace:*
+        version: link:../plugin-annotation
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   packages/plugin-pan:
     dependencies:
       '@embedpdf/core':

--- a/snippet/src/components/app.tsx
+++ b/snippet/src/components/app.tsx
@@ -132,6 +132,7 @@ import {
   isHighlightTool,
   getToolDefaultsById,
 } from '@embedpdf/plugin-annotation/preact';
+import { MeasurementPluginPackage } from '@embedpdf/plugin-measurement/preact';
 import { LoadingIndicator } from './ui/loading-indicator';
 import { PrintPluginConfig, PrintPluginPackage } from '@embedpdf/plugin-print/preact';
 import {
@@ -922,6 +923,21 @@ export const menuItems: Record<string, MenuItem<State>> = {
       storeState.plugins.ui.header.toolsHeader.visible === true &&
       storeState.plugins.ui.header.toolsHeader.visibleChild === 'shapeTools',
   },
+  measure: {
+    id: 'measure',
+    label: 'Measure',
+    type: 'action',
+    action: (registry) => {
+      const ui = registry.getPlugin<UIPlugin>(UI_PLUGIN_ID)?.provides();
+
+      if (ui) {
+        ui.setHeaderVisible({ id: 'toolsHeader', visible: true, visibleChild: 'measurementTools' });
+      }
+    },
+    active: (storeState) =>
+      storeState.plugins.ui.header.toolsHeader.visible === true &&
+      storeState.plugins.ui.header.toolsHeader.visibleChild === 'measurementTools',
+  },
   redaction: {
     id: 'redaction',
     label: 'Redaction',
@@ -972,7 +988,7 @@ export const menuItems: Record<string, MenuItem<State>> = {
     label: 'More',
     icon: 'dots',
     type: 'menu',
-    children: ['view', 'annotate', 'shapes', 'redaction' /*'fillAndSign', 'form'*/],
+    children: ['view', 'annotate', 'shapes', 'measure', 'redaction' /*'fillAndSign', 'form'*/],
     active: (storeState) =>
       storeState.plugins.ui.commandMenu.commandMenu.activeCommand === 'tabOverflow',
   },
@@ -1001,6 +1017,15 @@ export const menuItems: Record<string, MenuItem<State>> = {
     children: ['circle', 'square', 'polygon', 'polyline', 'line', 'lineArrow'],
     active: (storeState) =>
       storeState.plugins.ui.commandMenu.commandMenu.activeCommand === 'shapeToolOverflow',
+  },
+  measurementToolOverflow: {
+    id: 'measurementToolOverflow',
+    label: 'More',
+    icon: 'dots',
+    type: 'menu',
+    children: ['manualCalibration', 'measureDistance', 'measureArea', 'measurePerimeter'],
+    active: (storeState) =>
+      storeState.plugins.ui.commandMenu.commandMenu.activeCommand === 'measurementToolOverflow',
   },
   nextPage: {
     id: 'nextPage',
@@ -1270,6 +1295,94 @@ export const menuItems: Record<string, MenuItem<State>> = {
       }
     },
     active: (storeState) => storeState.plugins.annotation.activeToolId === 'polygon',
+  },
+  manualCalibration: {
+    id: 'manualCalibration',
+    label: 'Calibrate',
+    type: 'action',
+    icon: 'measureCalibrate',
+    iconProps: (storeState) => ({
+      primaryColor:
+        getToolDefaultsById(storeState.plugins.annotation, 'manualCalibration')?.strokeColor ??
+        '#2E7D32',
+    }),
+    action: (registry, state) => {
+      const annotation = registry.getPlugin<AnnotationPlugin>(ANNOTATION_PLUGIN_ID)?.provides();
+      if (annotation) {
+        if (state.plugins.annotation.activeToolId === 'manualCalibration') {
+          annotation.setActiveTool(null);
+        } else {
+          annotation.setActiveTool('manualCalibration');
+        }
+      }
+    },
+    active: (storeState) => storeState.plugins.annotation.activeToolId === 'manualCalibration',
+  },
+  measureDistance: {
+    id: 'measureDistance',
+    label: 'Distance',
+    type: 'action',
+    icon: 'measureDistance',
+    iconProps: (storeState) => ({
+      primaryColor:
+        getToolDefaultsById(storeState.plugins.annotation, 'measureDistance')?.strokeColor ??
+        '#1E88E5',
+    }),
+    action: (registry, state) => {
+      const annotation = registry.getPlugin<AnnotationPlugin>(ANNOTATION_PLUGIN_ID)?.provides();
+      if (annotation) {
+        if (state.plugins.annotation.activeToolId === 'measureDistance') {
+          annotation.setActiveTool(null);
+        } else {
+          annotation.setActiveTool('measureDistance');
+        }
+      }
+    },
+    active: (storeState) => storeState.plugins.annotation.activeToolId === 'measureDistance',
+  },
+  measureArea: {
+    id: 'measureArea',
+    label: 'Area',
+    type: 'action',
+    icon: 'measureArea',
+    iconProps: (storeState) => ({
+      primaryColor:
+        getToolDefaultsById(storeState.plugins.annotation, 'measureArea')?.strokeColor ?? '#1565C0',
+      secondaryColor:
+        getToolDefaultsById(storeState.plugins.annotation, 'measureArea')?.color ?? 'rgba(21,101,192,0.2)',
+    }),
+    action: (registry, state) => {
+      const annotation = registry.getPlugin<AnnotationPlugin>(ANNOTATION_PLUGIN_ID)?.provides();
+      if (annotation) {
+        if (state.plugins.annotation.activeToolId === 'measureArea') {
+          annotation.setActiveTool(null);
+        } else {
+          annotation.setActiveTool('measureArea');
+        }
+      }
+    },
+    active: (storeState) => storeState.plugins.annotation.activeToolId === 'measureArea',
+  },
+  measurePerimeter: {
+    id: 'measurePerimeter',
+    label: 'Perimeter',
+    type: 'action',
+    icon: 'measurePerimeter',
+    iconProps: (storeState) => ({
+      primaryColor:
+        getToolDefaultsById(storeState.plugins.annotation, 'measurePerimeter')?.strokeColor ?? '#F4511E',
+    }),
+    action: (registry, state) => {
+      const annotation = registry.getPlugin<AnnotationPlugin>(ANNOTATION_PLUGIN_ID)?.provides();
+      if (annotation) {
+        if (state.plugins.annotation.activeToolId === 'measurePerimeter') {
+          annotation.setActiveTool(null);
+        } else {
+          annotation.setActiveTool('measurePerimeter');
+        }
+      }
+    },
+    active: (storeState) => storeState.plugins.annotation.activeToolId === 'measurePerimeter',
   },
   freeText: {
     id: 'freeText',
@@ -1899,6 +2012,62 @@ export const components: Record<string, UIComponentType<State>> = {
       iconProps: getIconProps(menuItems.lineArrow, storeState),
     }),
   },
+  calibrateButton: {
+    type: 'iconButton',
+    id: 'calibrateButton',
+    props: {
+      commandId: 'manualCalibration',
+      active: false,
+      label: 'Calibrate',
+    },
+    mapStateToProps: (storeState, ownProps) => ({
+      ...ownProps,
+      active: isActive(menuItems.manualCalibration, storeState),
+      iconProps: getIconProps(menuItems.manualCalibration, storeState),
+    }),
+  },
+  distanceButton: {
+    type: 'iconButton',
+    id: 'distanceButton',
+    props: {
+      commandId: 'measureDistance',
+      active: false,
+      label: 'Distance',
+    },
+    mapStateToProps: (storeState, ownProps) => ({
+      ...ownProps,
+      active: isActive(menuItems.measureDistance, storeState),
+      iconProps: getIconProps(menuItems.measureDistance, storeState),
+    }),
+  },
+  areaButton: {
+    type: 'iconButton',
+    id: 'areaButton',
+    props: {
+      commandId: 'measureArea',
+      active: false,
+      label: 'Area',
+    },
+    mapStateToProps: (storeState, ownProps) => ({
+      ...ownProps,
+      active: isActive(menuItems.measureArea, storeState),
+      iconProps: getIconProps(menuItems.measureArea, storeState),
+    }),
+  },
+  perimeterButton: {
+    type: 'iconButton',
+    id: 'perimeterButton',
+    props: {
+      commandId: 'measurePerimeter',
+      active: false,
+      label: 'Perimeter',
+    },
+    mapStateToProps: (storeState, ownProps) => ({
+      ...ownProps,
+      active: isActive(menuItems.measurePerimeter, storeState),
+      iconProps: getIconProps(menuItems.measurePerimeter, storeState),
+    }),
+  },
   polylineButton: {
     type: 'iconButton',
     id: 'polylineButton',
@@ -2269,6 +2438,19 @@ export const components: Record<string, UIComponentType<State>> = {
       active: isActive(menuItems.shapes, storeState),
     }),
   },
+  measureTab: {
+    type: 'tabButton',
+    id: 'measureTab',
+    props: {
+      label: 'Measure',
+      commandId: 'measure',
+      active: false,
+    },
+    mapStateToProps: (storeState, ownProps) => ({
+      ...ownProps,
+      active: isActive(menuItems.measure, storeState),
+    }),
+  },
   redactionTab: {
     type: 'tabButton',
     id: 'redactionTab',
@@ -2347,12 +2529,25 @@ export const components: Record<string, UIComponentType<State>> = {
       active: isActive(menuItems.shapeToolOverflow, storeState),
     }),
   },
+  measurementToolOverflowButton: {
+    type: 'iconButton',
+    id: 'measurementToolOverflowButton',
+    props: {
+      label: 'More',
+      commandId: 'measurementToolOverflow',
+      active: false,
+    },
+    mapStateToProps: (storeState, ownProps) => ({
+      ...ownProps,
+      active: isActive(menuItems.measurementToolOverflow, storeState),
+    }),
+  },
   selectButton: {
     type: 'selectButton',
     id: 'selectButton',
     props: {
       menuCommandId: 'tabOverflow',
-      commandIds: ['view', 'annotate', 'shapes', 'redaction'],
+      commandIds: ['view', 'annotate', 'shapes', 'measure', 'redaction'],
       activeCommandId: 'view',
       active: false,
     },
@@ -2372,10 +2567,11 @@ export const components: Record<string, UIComponentType<State>> = {
       { componentId: 'viewTab', priority: 1, className: 'hidden @min-[500px]:block' },
       { componentId: 'annotateTab', priority: 2, className: 'hidden @min-[800px]:block' },
       { componentId: 'shapesTab', priority: 3, className: 'hidden @min-[800px]:block' },
-      { componentId: 'redactionTab', priority: 4, className: 'hidden @min-[800px]:block' },
+      { componentId: 'measureTab', priority: 4, className: 'hidden @min-[800px]:block' },
+      { componentId: 'redactionTab', priority: 5, className: 'hidden @min-[800px]:block' },
       {
         componentId: 'tabOverflowButton',
-        priority: 5,
+        priority: 6,
         className: 'hidden @min-[500px]:block @min-[800px]:hidden',
       },
     ],
@@ -2526,6 +2722,29 @@ export const components: Record<string, UIComponentType<State>> = {
       gap: 10,
     },
   },
+  measurementTools: {
+    id: 'measurementTools',
+    type: 'groupedItems',
+    slots: [
+      { componentId: 'calibrateButton', priority: 0 },
+      { componentId: 'distanceButton', priority: 1 },
+      { componentId: 'areaButton', priority: 2, className: 'hidden @min-[520px]:block' },
+      { componentId: 'perimeterButton', priority: 3, className: 'hidden @min-[520px]:block' },
+      {
+        componentId: 'measurementToolOverflowButton',
+        priority: 4,
+        className: 'block @min-[520px]:hidden',
+      },
+      { componentId: 'divider1', priority: 5 },
+      { componentId: 'styleButton', priority: 6 },
+      { componentId: 'divider1', priority: 7 },
+      { componentId: 'undoButton', priority: 8 },
+      { componentId: 'redoButton', priority: 9 },
+    ],
+    props: {
+      gap: 10,
+    },
+  },
   redactionTools: {
     id: 'redactionTools',
     type: 'groupedItems',
@@ -2590,7 +2809,8 @@ export const components: Record<string, UIComponentType<State>> = {
     slots: [
       { componentId: 'annotationTools', priority: 0 },
       { componentId: 'shapeTools', priority: 1 },
-      { componentId: 'redactionTools', priority: 2 },
+      { componentId: 'measurementTools', priority: 2 },
+      { componentId: 'redactionTools', priority: 3 },
     ],
     getChildContext: (props) => ({
       direction:
@@ -2873,6 +3093,23 @@ export function PDFViewer({ config }: PDFViewerProps) {
           createPluginRegistration(TilingPluginPackage, pluginConfigs.tiling),
           createPluginRegistration(ThumbnailPluginPackage, pluginConfigs.thumbnail),
           createPluginRegistration(AnnotationPluginPackage),
+          createPluginRegistration(MeasurementPluginPackage, {
+            onCalibrationRequest: async ({ unit }) => {
+              const message = `Enter the real-world distance (${unit}) for the selected line`;
+              const response = globalThis.prompt?.(message, '');
+              if (response === null || response === undefined) {
+                return null;
+              }
+
+              const normalized = response.trim().replace(',', '.');
+              if (!normalized) {
+                return null;
+              }
+
+              const parsed = Number.parseFloat(normalized);
+              return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+            },
+          }),
           createPluginRegistration(PrintPluginPackage),
           createPluginRegistration(FullscreenPluginPackage),
           createPluginRegistration(BookmarkPluginPackage),

--- a/snippet/src/components/icons/index.tsx
+++ b/snippet/src/components/icons/index.tsx
@@ -65,6 +65,10 @@ import { RedactIcon } from './redact';
 import { IconComponent } from './types';
 import { RedactAreaIcon } from './redact-area';
 import { CheckIcon } from './check';
+import { MeasureCalibrateIcon } from './measure-calibrate';
+import { MeasureDistanceIcon } from './measure-distance';
+import { MeasureAreaIcon } from './measure-area';
+import { MeasurePerimeterIcon } from './measure-perimeter';
 
 export type Icons = {
   [key: string]: IconComponent;
@@ -137,4 +141,8 @@ export const icons: Icons = {
   redact: RedactIcon,
   redactArea: RedactAreaIcon,
   check: CheckIcon,
+  measureCalibrate: MeasureCalibrateIcon,
+  measureDistance: MeasureDistanceIcon,
+  measureArea: MeasureAreaIcon,
+  measurePerimeter: MeasurePerimeterIcon,
 };

--- a/snippet/src/components/icons/measure-area.tsx
+++ b/snippet/src/components/icons/measure-area.tsx
@@ -1,0 +1,33 @@
+import { h } from 'preact';
+import { IconProps } from './types';
+
+export const MeasureAreaIcon = ({
+  size = 24,
+  strokeWidth = 2.2,
+  primaryColor = 'currentColor',
+  secondaryColor = 'currentColor',
+  className,
+  title,
+}: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={primaryColor}
+    stroke-width={strokeWidth}
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class={className}
+    role="img"
+    aria-label={title}
+  >
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path
+      d="M6 17l2-10l6-3l4 5l-2 9z"
+      fill={secondaryColor}
+      fill-opacity="0.2"
+    />
+    <path d="M6 17l2-10l6-3l4 5l-2 9z" />
+  </svg>
+);

--- a/snippet/src/components/icons/measure-calibrate.tsx
+++ b/snippet/src/components/icons/measure-calibrate.tsx
@@ -1,0 +1,32 @@
+import { h } from 'preact';
+import { IconProps } from './types';
+
+export const MeasureCalibrateIcon = ({
+  size = 24,
+  strokeWidth = 2.2,
+  primaryColor = 'currentColor',
+  className,
+  title,
+}: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={primaryColor}
+    stroke-width={strokeWidth}
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class={className}
+    role="img"
+    aria-label={title}
+  >
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <circle cx="12" cy="12" r="3" fill="none" />
+    <path d="M12 5v2" />
+    <path d="M12 17v2" />
+    <path d="M5 12h2" />
+    <path d="M17 12h2" />
+    <path d="M6 18l12-12" />
+  </svg>
+);

--- a/snippet/src/components/icons/measure-distance.tsx
+++ b/snippet/src/components/icons/measure-distance.tsx
@@ -1,0 +1,29 @@
+import { h } from 'preact';
+import { IconProps } from './types';
+
+export const MeasureDistanceIcon = ({
+  size = 24,
+  strokeWidth = 2.2,
+  primaryColor = 'currentColor',
+  className,
+  title,
+}: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={primaryColor}
+    stroke-width={strokeWidth}
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class={className}
+    role="img"
+    aria-label={title}
+  >
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M6 18l12-12" />
+    <path d="M7 7l-3 3l3 3" />
+    <path d="M17 11l3 -3l-3 -3" />
+  </svg>
+);

--- a/snippet/src/components/icons/measure-perimeter.tsx
+++ b/snippet/src/components/icons/measure-perimeter.tsx
@@ -1,0 +1,32 @@
+import { h } from 'preact';
+import { IconProps } from './types';
+
+export const MeasurePerimeterIcon = ({
+  size = 24,
+  strokeWidth = 2.2,
+  primaryColor = 'currentColor',
+  className,
+  title,
+}: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={primaryColor}
+    stroke-width={strokeWidth}
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class={className}
+    role="img"
+    aria-label={title}
+  >
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M6 17l2-10l6-3l4 5l-2 9z" />
+    <circle cx="6" cy="17" r="0.6" fill={primaryColor} stroke="none" />
+    <circle cx="8" cy="7" r="0.6" fill={primaryColor} stroke="none" />
+    <circle cx="14" cy="4" r="0.6" fill={primaryColor} stroke="none" />
+    <circle cx="18" cy="9" r="0.6" fill={primaryColor} stroke="none" />
+    <circle cx="16" cy="18" r="0.6" fill={primaryColor} stroke="none" />
+  </svg>
+);


### PR DESCRIPTION
## Summary
- extract measurement overlay rendering logic from the base line and polygon SVG components so they can be reused without measurement concerns
- add dedicated measurement-aware line and polygon components that compose the base shapes and render shared measurement labels when metadata is present
- centralise measurement label utilities for reuse across measurement components

## Testing
- pnpm --filter @embedpdf/plugin-annotation lint *(fails: existing lint violations across the package)*

------
https://chatgpt.com/codex/tasks/task_e_68f0a81426b4832d8a1ba4da28333cbf