### PR TITLE
Add AI-powered redaction suggestions sidebar

### DIFF
--- a/packages/plugin-redaction/CHANGELOG.md
+++ b/packages/plugin-redaction/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.3.14
 
+### Patch Changes
+
+- Add AI redaction suggestion utilities, including a reusable sidebar component and hook for fetching suggestions from external services.
+
 ## 1.3.13
 
 ## 1.3.12

--- a/packages/plugin-redaction/src/shared/components/index.ts
+++ b/packages/plugin-redaction/src/shared/components/index.ts
@@ -1,2 +1,3 @@
 export * from './redaction-layer';
 export * from './types';
+export * from './redaction-suggestions-sidebar';

--- a/packages/plugin-redaction/src/shared/components/redaction-suggestions-sidebar.tsx
+++ b/packages/plugin-redaction/src/shared/components/redaction-suggestions-sidebar.tsx
@@ -1,0 +1,312 @@
+import { Fragment, JSX, useCallback, useEffect, useMemo, useState } from '@framework';
+import {
+  useRedactionSuggestions,
+  UseRedactionSuggestionsOptions,
+} from '../hooks/use-redaction-suggestions';
+import { useRedactionCapability } from '../hooks';
+import { RedactionSuggestion, RedactionSuggestionOccurrence } from '../suggestions';
+
+interface AppliedRedactionRecord {
+  ids: { page: number; id: string }[];
+}
+
+export interface RedactionSuggestionsSidebarProps extends UseRedactionSuggestionsOptions {
+  className?: string;
+  title?: string;
+  description?: string;
+  emptyState?: string;
+  errorState?: string;
+  loadingLabel?: string;
+  extractingLabel?: string;
+}
+
+const defaultEmptyState = 'No AI redaction suggestions were returned for this document.';
+const defaultErrorState = 'Unable to fetch AI redaction suggestions.';
+const defaultLoadingLabel = 'Fetching suggestions…';
+const defaultExtractingLabel = 'Preparing document text…';
+
+const formatScore = (score: number): string => {
+  if (!Number.isFinite(score)) return '—';
+  return `${Math.round(score * 1000) / 10}%`;
+};
+
+const formatOccurrenceLabel = (
+  occurrence: RedactionSuggestionOccurrence,
+  index: number,
+): string => {
+  const pageList = occurrence.pages.map((page) => page + 1).join(', ');
+  const pageLabel = pageList
+    ? `Page${occurrence.pages.length > 1 ? 's' : ''} ${pageList}`
+    : 'Location unavailable';
+  return `Match ${index + 1} · ${pageLabel}`;
+};
+
+const normalizeSnippet = (text: string): string => {
+  if (!text) return '';
+  return text.replace(/\s+/g, ' ').trim();
+};
+
+export const RedactionSuggestionsSidebar = ({
+  className,
+  title = 'AI Redaction Suggestions',
+  description = 'Review potential redactions identified by the AI service and add them to the document.',
+  emptyState = defaultEmptyState,
+  errorState = defaultErrorState,
+  loadingLabel = defaultLoadingLabel,
+  extractingLabel = defaultExtractingLabel,
+  serviceUrl,
+  enabled,
+  autoFetch,
+  minScore,
+  buildRequestInit,
+  parseResponse,
+}: RedactionSuggestionsSidebarProps): JSX.Element => {
+  const hookOptions = useMemo(
+    () => ({ serviceUrl, enabled, autoFetch, minScore, buildRequestInit, parseResponse }),
+    [serviceUrl, enabled, autoFetch, minScore, buildRequestInit, parseResponse],
+  );
+
+  const { suggestions, loading, extracting, error, ready, lastUpdated, document, refetch } =
+    useRedactionSuggestions(hookOptions);
+  const { provides: redaction } = useRedactionCapability();
+
+  const [applied, setApplied] = useState<Record<string, AppliedRedactionRecord>>({});
+
+  useEffect(() => {
+    setApplied({});
+  }, [document?.id]);
+
+  useEffect(() => {
+    if (enabled === false) {
+      setApplied({});
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!redaction) return;
+    return redaction.onPendingChange((map) => {
+      setApplied((prev) => {
+        let changed = false;
+        const next: Record<string, AppliedRedactionRecord> = {};
+        for (const [suggestionId, record] of Object.entries(prev)) {
+          const stillPresent = record.ids.every(({ page, id }) =>
+            (map[page] ?? []).some((item) => item.id === id),
+          );
+          if (stillPresent) {
+            next[suggestionId] = record;
+          } else {
+            changed = true;
+          }
+        }
+        if (!changed && Object.keys(next).length === Object.keys(prev).length) {
+          return prev;
+        }
+        return next;
+      });
+    });
+  }, [redaction]);
+
+  const handleToggle = useCallback(
+    (suggestion: RedactionSuggestion, checked: boolean) => {
+      if (!redaction) return;
+
+      if (checked) {
+        setApplied((prev) => {
+          if (prev[suggestion.id]) return prev;
+          const items = suggestion.occurrences
+            .filter((occ) => occ.status === 'ready')
+            .flatMap((occ) => occ.items);
+          if (!items.length) return prev;
+          redaction.addPending(items);
+          return {
+            ...prev,
+            [suggestion.id]: {
+              ids: items.map((item) => ({ page: item.page, id: item.id })),
+            },
+          };
+        });
+      } else {
+        setApplied((prev) => {
+          const record = prev[suggestion.id];
+          if (!record) return prev;
+          record.ids.forEach(({ page, id }) => {
+            redaction.removePending(page, id);
+          });
+          const next = { ...prev };
+          delete next[suggestion.id];
+          return next;
+        });
+      }
+    },
+    [redaction],
+  );
+
+  const suggestionsDisabled = enabled === false;
+  const isDisabled = !redaction || !ready;
+  const hasSuggestions = suggestions.length > 0;
+  const showEmpty =
+    !loading && !extracting && ready && !hasSuggestions && !error && !suggestionsDisabled;
+  const showError = Boolean(error);
+  const showLoading = loading;
+  const showExtracting = !loading && extracting;
+  const showDisabled = suggestionsDisabled;
+  const showAwaitingDocument =
+    !document && !extracting && !loading && !error && !suggestionsDisabled;
+
+  const handleRefresh = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
+  return (
+    <div
+      className={
+        className ??
+        'flex h-full flex-col border-l border-gray-200 bg-white text-gray-900 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100'
+      }
+    >
+      <div className="border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+        <h2 className="text-sm font-semibold leading-5">{title}</h2>
+        <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">{description}</p>
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-b border-gray-200 px-4 py-2 text-xs text-gray-600 dark:border-gray-700 dark:text-gray-400">
+        <div className="flex flex-col">
+          <span className="font-medium text-gray-700 dark:text-gray-300">
+            {hasSuggestions
+              ? `${suggestions.length} suggestion${suggestions.length === 1 ? '' : 's'}`
+              : 'Suggestions'}
+          </span>
+          {lastUpdated ? (
+            <span className="text-[11px] text-gray-500 dark:text-gray-500">
+              Updated {lastUpdated.toLocaleTimeString()}
+            </span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={handleRefresh}
+          disabled={showLoading || showExtracting || !ready}
+          className="rounded border border-gray-300 px-2 py-1 text-xs font-medium text-gray-700 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+        >
+          Refresh
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-auto px-4 py-3">
+        {showAwaitingDocument ? (
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Load a document to request AI redaction suggestions.
+          </p>
+        ) : null}
+
+        {showDisabled ? (
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Redaction suggestions are disabled for the current configuration.
+          </p>
+        ) : null}
+
+        {showExtracting ? (
+          <p className="text-sm text-gray-600 dark:text-gray-400">{extractingLabel}</p>
+        ) : null}
+
+        {showLoading ? (
+          <p className="text-sm text-gray-600 dark:text-gray-400">{loadingLabel}</p>
+        ) : null}
+
+        {showError ? (
+          <div className="space-y-2 text-sm text-red-600 dark:text-red-400">
+            <p>{errorState}</p>
+            <p className="text-xs text-red-500 dark:text-red-400">{error?.message}</p>
+            <button
+              type="button"
+              onClick={handleRefresh}
+              className="rounded border border-red-400 px-2 py-1 text-xs font-medium text-red-600 transition hover:bg-red-50 dark:border-red-600 dark:text-red-300 dark:hover:bg-red-900/30"
+            >
+              Try again
+            </button>
+          </div>
+        ) : null}
+
+        {showEmpty ? (
+          <p className="text-sm text-gray-600 dark:text-gray-400">{emptyState}</p>
+        ) : null}
+
+        {ready && hasSuggestions ? (
+          <ul className="space-y-3">
+            {suggestions.map((suggestion) => {
+              const checked = Boolean(applied[suggestion.id]);
+              const disabled = isDisabled || suggestion.readyOccurrences === 0;
+              return (
+                <li
+                  key={suggestion.id}
+                  className="rounded-md border border-gray-200 bg-white p-3 shadow-sm transition hover:border-gray-300 dark:border-gray-700 dark:bg-gray-900/60 dark:hover:border-gray-600"
+                >
+                  <label className="flex items-start gap-3">
+                    <input
+                      type="checkbox"
+                      className="mt-1 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                      checked={checked}
+                      disabled={disabled}
+                      onChange={(evt) => handleToggle(suggestion, evt.currentTarget.checked)}
+                    />
+                    <div className="flex-1 space-y-2">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div className="flex flex-col">
+                          <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                            {suggestion.entity}
+                          </span>
+                          <span className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                            {suggestion.entityType}
+                          </span>
+                        </div>
+                        <span className="text-xs font-medium text-gray-600 dark:text-gray-300">
+                          Confidence {formatScore(suggestion.averageScore)}
+                        </span>
+                      </div>
+
+                      <p className="text-xs text-gray-600 dark:text-gray-400">
+                        {suggestion.readyOccurrences} of {suggestion.totalOccurrences} occurrence
+                        {suggestion.totalOccurrences === 1 ? '' : 's'} located in the document.
+                      </p>
+
+                      <div className="space-y-2">
+                        {suggestion.occurrences.map((occurrence, index) => (
+                          <Fragment key={occurrence.id}>
+                            <div className="rounded border border-gray-200 bg-gray-50 p-2 text-xs text-gray-700 dark:border-gray-600 dark:bg-gray-800/80 dark:text-gray-200">
+                              <div className="flex flex-wrap items-center justify-between gap-2">
+                                <span className="font-medium text-gray-700 dark:text-gray-200">
+                                  {formatOccurrenceLabel(occurrence, index)}
+                                </span>
+                                <span
+                                  className={
+                                    occurrence.status === 'ready'
+                                      ? 'text-[11px] font-medium uppercase text-emerald-600 dark:text-emerald-400'
+                                      : 'text-[11px] font-medium uppercase text-amber-600 dark:text-amber-400'
+                                  }
+                                >
+                                  {occurrence.status === 'ready' ? 'Ready' : 'Unmapped'}
+                                </span>
+                              </div>
+                              <p className="mt-1 text-[11px] text-gray-600 dark:text-gray-300">
+                                {normalizeSnippet(occurrence.text || suggestion.entity)}
+                              </p>
+                              {occurrence.status === 'unmapped' && occurrence.reason ? (
+                                <p className="mt-1 text-[11px] text-amber-600 dark:text-amber-400">
+                                  {occurrence.reason}
+                                </p>
+                              ) : null}
+                            </div>
+                          </Fragment>
+                        ))}
+                      </div>
+                    </div>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/packages/plugin-redaction/src/shared/hooks/index.ts
+++ b/packages/plugin-redaction/src/shared/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './use-redaction';
+export * from './use-redaction-suggestions';

--- a/packages/plugin-redaction/src/shared/hooks/use-redaction-suggestions.ts
+++ b/packages/plugin-redaction/src/shared/hooks/use-redaction-suggestions.ts
@@ -1,0 +1,272 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from '@framework';
+import { useRegistry } from '@embedpdf/core/@framework';
+import { useLoaderCapability } from '@embedpdf/plugin-loader/@framework';
+import { PdfDocumentObject } from '@embedpdf/models';
+import {
+  buildDocumentTextIndex,
+  DocumentTextIndex,
+  RawRedactionSuggestion,
+  RedactionSuggestion,
+  transformSuggestions,
+} from '../suggestions';
+
+interface RequestBuilderArgs {
+  text: string;
+  document: PdfDocumentObject;
+}
+
+export interface UseRedactionSuggestionsOptions {
+  serviceUrl: string;
+  enabled?: boolean;
+  autoFetch?: boolean;
+  minScore?: number;
+  buildRequestInit?: (args: RequestBuilderArgs) => Promise<RequestInit> | RequestInit;
+  parseResponse?: (response: any) => RawRedactionSuggestion[];
+}
+
+export interface UseRedactionSuggestionsResult {
+  document: PdfDocumentObject | null;
+  extracting: boolean;
+  loading: boolean;
+  error: Error | null;
+  suggestions: RedactionSuggestion[];
+  ready: boolean;
+  lastUpdated: Date | null;
+  refetch: () => Promise<void>;
+}
+
+const defaultBuildRequestInit = ({ text }: RequestBuilderArgs): RequestInit => ({
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ text }),
+});
+
+const defaultParseResponse = (response: any): RawRedactionSuggestion[] => {
+  if (!Array.isArray(response)) {
+    throw new Error('Unexpected response format from redaction suggestion service');
+  }
+  return response as RawRedactionSuggestion[];
+};
+
+function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {
+  if (!headers) return {};
+  if (headers instanceof Headers) {
+    const record: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      record[key] = value;
+    });
+    return record;
+  }
+  if (Array.isArray(headers)) {
+    const record: Record<string, string> = {};
+    for (const [key, value] of headers) {
+      record[key] = value;
+    }
+    return record;
+  }
+  return { ...headers };
+}
+
+function mergeHeaders(
+  existing: HeadersInit | undefined,
+  defaults: Record<string, string>,
+): HeadersInit {
+  const normalized = normalizeHeaders(existing);
+  for (const [key, value] of Object.entries(defaults)) {
+    const lowerKey = key.toLowerCase();
+    const hasKey = Object.keys(normalized).some((k) => k.toLowerCase() === lowerKey);
+    if (!hasKey) {
+      normalized[key] = value;
+    }
+  }
+  return normalized;
+}
+
+export function useRedactionSuggestions(
+  options: UseRedactionSuggestionsOptions,
+): UseRedactionSuggestionsResult {
+  const { registry, pluginsReady } = useRegistry();
+  const { provides: loader } = useLoaderCapability();
+
+  const [document, setDocument] = useState<PdfDocumentObject | null>(
+    () => loader?.getDocument() ?? null,
+  );
+  const [textIndex, setTextIndex] = useState<DocumentTextIndex | null>(null);
+  const [extracting, setExtracting] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [suggestions, setSuggestions] = useState<RedactionSuggestion[]>([]);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const enabled = options.enabled !== false;
+  const autoFetch = options.autoFetch ?? true;
+
+  useEffect(() => {
+    if (!loader) return;
+
+    const offDocumentLoaded = loader.onDocumentLoaded((doc) => {
+      setDocument(doc);
+    });
+
+    const offLoaderEvent = loader.onLoaderEvent((event) => {
+      if (event.type === 'start') {
+        setDocument(null);
+      }
+    });
+
+    const currentDocument = loader.getDocument();
+    if (currentDocument) {
+      setDocument(currentDocument);
+    }
+
+    return () => {
+      offDocumentLoaded?.();
+      offLoaderEvent?.();
+    };
+  }, [loader]);
+
+  useEffect(() => {
+    setSuggestions([]);
+    setLastUpdated(null);
+    setError(null);
+    setTextIndex(null);
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+  }, [document?.id]);
+
+  useEffect(() => {
+    if (enabled === false) {
+      setSuggestions([]);
+      setLastUpdated(null);
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!document || !registry || !pluginsReady || !enabled) {
+      setTextIndex(null);
+      setExtracting(false);
+      return;
+    }
+
+    let cancelled = false;
+    setExtracting(true);
+
+    (async () => {
+      try {
+        const index = await buildDocumentTextIndex(registry.getEngine(), document);
+        if (cancelled) return;
+        setTextIndex(index);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setTextIndex(null);
+      } finally {
+        if (!cancelled) {
+          setExtracting(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [document, registry, pluginsReady, enabled]);
+
+  useEffect(
+    () => () => {
+      abortControllerRef.current?.abort();
+    },
+    [],
+  );
+
+  const refetch = useCallback(async () => {
+    if (!enabled) return;
+    if (!textIndex) return;
+    const builder = options.buildRequestInit ?? defaultBuildRequestInit;
+    const parser = options.parseResponse ?? defaultParseResponse;
+
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const initFromBuilder = await builder({
+        text: textIndex.text,
+        document: textIndex.document,
+      });
+
+      const finalInit: RequestInit = { ...initFromBuilder };
+
+      if (!finalInit.method) {
+        finalInit.method = 'POST';
+      }
+
+      if (finalInit.body === undefined) {
+        finalInit.body = JSON.stringify({ text: textIndex.text });
+        finalInit.headers = mergeHeaders(finalInit.headers, { 'Content-Type': 'application/json' });
+      }
+
+      if (!finalInit.signal) {
+        finalInit.signal = controller.signal;
+      }
+
+      const response = await globalThis.fetch(options.serviceUrl, finalInit);
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch redaction suggestions: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const json = await response.json();
+      const parsed = parser(json);
+      const transformed = transformSuggestions(parsed, textIndex, {
+        minScore: options.minScore,
+      });
+
+      setSuggestions(transformed);
+      setLastUpdated(new Date());
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        return;
+      }
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      if (abortControllerRef.current === controller) {
+        abortControllerRef.current = null;
+      }
+      setLoading(false);
+    }
+  }, [
+    enabled,
+    options.buildRequestInit,
+    options.minScore,
+    options.parseResponse,
+    options.serviceUrl,
+    textIndex,
+  ]);
+
+  useEffect(() => {
+    if (!autoFetch) return;
+    if (!enabled) return;
+    if (!textIndex) return;
+    refetch();
+  }, [autoFetch, enabled, textIndex, refetch]);
+
+  const ready = useMemo(() => Boolean(textIndex) && enabled, [textIndex, enabled]);
+
+  return {
+    document,
+    extracting,
+    loading,
+    error,
+    suggestions,
+    ready,
+    lastUpdated,
+    refetch,
+  };
+}

--- a/packages/plugin-redaction/src/shared/index.ts
+++ b/packages/plugin-redaction/src/shared/index.ts
@@ -1,3 +1,4 @@
 export * from './hooks';
 export * from './components';
+export * from './suggestions';
 export * from '@embedpdf/plugin-redaction';

--- a/packages/plugin-redaction/src/shared/suggestions/index.ts
+++ b/packages/plugin-redaction/src/shared/suggestions/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './utils';

--- a/packages/plugin-redaction/src/shared/suggestions/types.ts
+++ b/packages/plugin-redaction/src/shared/suggestions/types.ts
@@ -1,0 +1,51 @@
+import { PdfDocumentObject, Rect } from '@embedpdf/models';
+import { RedactionItem } from '@embedpdf/plugin-redaction';
+
+export interface RawRedactionOccurrence {
+  start: number;
+  end: number;
+}
+
+export interface RawRedactionSuggestion {
+  average_score: number;
+  entity: string;
+  entity_type: string;
+  occurrences: RawRedactionOccurrence[];
+}
+
+export interface TextContentSlice {
+  pageIndex: number;
+  start: number;
+  end: number;
+  rect: Rect;
+  content: string;
+}
+
+export interface DocumentTextIndex {
+  document: PdfDocumentObject;
+  slices: TextContentSlice[];
+  text: string;
+}
+
+export type OccurrenceStatus = 'ready' | 'unmapped';
+
+export interface RedactionSuggestionOccurrence {
+  id: string;
+  start: number;
+  end: number;
+  text: string;
+  items: RedactionItem[];
+  pages: number[];
+  status: OccurrenceStatus;
+  reason?: string;
+}
+
+export interface RedactionSuggestion {
+  id: string;
+  entity: string;
+  entityType: string;
+  averageScore: number;
+  totalOccurrences: number;
+  readyOccurrences: number;
+  occurrences: RedactionSuggestionOccurrence[];
+}

--- a/packages/plugin-redaction/src/shared/suggestions/utils.ts
+++ b/packages/plugin-redaction/src/shared/suggestions/utils.ts
@@ -1,0 +1,185 @@
+import { PdfDocumentObject, PdfEngine, PdfTextRectObject, Rect, uuidV4 } from '@embedpdf/models';
+import {
+  DocumentTextIndex,
+  RawRedactionSuggestion,
+  RedactionSuggestion,
+  RedactionSuggestionOccurrence,
+  TextContentSlice,
+} from './types';
+
+function cloneRect(rect: Rect): Rect {
+  return {
+    origin: { x: rect.origin.x, y: rect.origin.y },
+    size: { width: rect.size.width, height: rect.size.height },
+  };
+}
+
+function getBoundingRect(rects: Rect[]): Rect | null {
+  if (!rects.length) return null;
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  for (const rect of rects) {
+    const { origin, size } = rect;
+    minX = Math.min(minX, origin.x);
+    minY = Math.min(minY, origin.y);
+    maxX = Math.max(maxX, origin.x + size.width);
+    maxY = Math.max(maxY, origin.y + size.height);
+  }
+
+  if (!isFinite(minX) || !isFinite(minY) || !isFinite(maxX) || !isFinite(maxY)) {
+    return null;
+  }
+
+  return {
+    origin: { x: minX, y: minY },
+    size: { width: maxX - minX, height: maxY - minY },
+  };
+}
+
+export async function buildDocumentTextIndex(
+  engine: PdfEngine,
+  document: PdfDocumentObject,
+): Promise<DocumentTextIndex> {
+  const slices: TextContentSlice[] = [];
+  let fullText = '';
+  let cursor = 0;
+
+  for (const page of document.pages) {
+    let rects: PdfTextRectObject[] = [];
+    try {
+      rects = await engine.getPageTextRects(document, page).toPromise();
+    } catch (error) {
+      const wrappedError =
+        error instanceof Error
+          ? error
+          : new Error(`Failed to extract text rectangles for page ${page.index + 1}`);
+      throw wrappedError;
+    }
+
+    for (const rect of rects) {
+      const content = rect.content ?? '';
+      if (!content.length) continue;
+
+      const start = cursor;
+      const end = start + content.length;
+
+      slices.push({
+        pageIndex: page.index,
+        start,
+        end,
+        rect: cloneRect(rect.rect),
+        content,
+      });
+
+      fullText += content;
+      cursor = end;
+    }
+  }
+
+  return {
+    document,
+    slices,
+    text: fullText,
+  };
+}
+
+interface TransformOptions {
+  minScore?: number;
+}
+
+export function transformSuggestions(
+  raw: RawRedactionSuggestion[],
+  index: DocumentTextIndex,
+  options: TransformOptions = {},
+): RedactionSuggestion[] {
+  const minScore = options.minScore ?? 0;
+  const { slices, text } = index;
+  const textLength = text.length;
+
+  const suggestions: RedactionSuggestion[] = [];
+
+  for (const suggestion of raw) {
+    if (!suggestion) continue;
+    if (!suggestion.occurrences?.length) continue;
+    if (Number.isFinite(minScore) && suggestion.average_score < minScore) continue;
+
+    const occurrences: RedactionSuggestionOccurrence[] = [];
+
+    for (const occ of suggestion.occurrences) {
+      const occurrenceId = uuidV4();
+      const start = Math.max(0, Math.min(textLength, Math.max(0, occ.start)));
+      const end = Math.max(start, Math.min(textLength, Math.max(occ.end, occ.start)));
+      const textSnippet = text.slice(start, end) || suggestion.entity;
+
+      const overlappingSlices = slices.filter((slice) => start < slice.end && end > slice.start);
+
+      if (!overlappingSlices.length) {
+        occurrences.push({
+          id: occurrenceId,
+          start,
+          end,
+          text: textSnippet,
+          items: [],
+          pages: [],
+          status: 'unmapped',
+          reason: 'Unable to locate matching text in the document',
+        });
+        continue;
+      }
+
+      const perPage = new Map<number, Rect[]>();
+      for (const slice of overlappingSlices) {
+        const list = perPage.get(slice.pageIndex);
+        const rectClone = cloneRect(slice.rect);
+        if (list) list.push(rectClone);
+        else perPage.set(slice.pageIndex, [rectClone]);
+      }
+
+      const items = Array.from(perPage.entries()).flatMap(([pageIndex, rects]) => {
+        const rect = getBoundingRect(rects);
+        if (!rect) return [];
+        return [
+          {
+            id: occurrenceId,
+            kind: 'text' as const,
+            page: pageIndex,
+            rect,
+            rects,
+          },
+        ];
+      });
+
+      const pages = Array.from(perPage.keys()).sort((a, b) => a - b);
+
+      occurrences.push({
+        id: occurrenceId,
+        start,
+        end,
+        text: textSnippet,
+        items,
+        pages,
+        status: items.length ? 'ready' : 'unmapped',
+        reason: items.length ? undefined : 'Unable to derive redaction rectangles',
+      });
+    }
+
+    const readyOccurrences = occurrences.filter((occ) => occ.status === 'ready');
+
+    suggestions.push({
+      id: uuidV4(),
+      entity: suggestion.entity,
+      entityType: suggestion.entity_type,
+      averageScore: suggestion.average_score,
+      totalOccurrences: suggestion.occurrences.length,
+      readyOccurrences: readyOccurrences.length,
+      occurrences: occurrences.sort((a, b) => a.start - b.start),
+    });
+  }
+
+  suggestions.sort((a, b) => b.averageScore - a.averageScore);
+
+  return suggestions;
+}


### PR DESCRIPTION
## Summary
- add redaction suggestion types and transformation utilities that translate REST responses into pending redactions
- introduce a reusable `useRedactionSuggestions` hook and sidebar component for fetching, displaying, and applying AI-driven suggestions
- expose the new tooling through shared exports and document the addition in the plugin changelog

## Testing
- pnpm exec tsc --noEmit --project packages/plugin-redaction/tsconfig.json *(fails: repository lacks resolved workspace type definitions in CI environment)*
- pnpm --filter @embedpdf/plugin-redaction lint *(fails: pre-existing lint violations in the package)*

------
https://chatgpt.com/codex/tasks/task_e_68f0be1ed040832dabf064ee6d4f6ff1