### PR TITLE
Improve Pdfium text run merging for the a11y layer

### DIFF
--- a/packages/engines/src/lib/pdfium/engine.ts
+++ b/packages/engines/src/lib/pdfium/engine.ts
@@ -8234,6 +8234,8 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       pageBottom?: number;
       firstIndex?: number;
       lastIndex?: number;
+      angle?: number;
+      charCount: number;
     };
 
     type McidInfo = {
@@ -8244,6 +8246,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       runs: Map<number, McidRunAccumulator>;
     };
 
+    const GLOBAL_MCID = -1;
     const mcidMap = new Map<number, McidInfo>();
     const ensureEntry = (mcid: number): McidInfo => {
       let info = mcidMap.get(mcid);
@@ -8271,11 +8274,8 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
         return;
       }
 
-      const mcid = this.pdfiumModule.FPDFPageObj_GetMarkedContentID(objPtr);
-      if (mcid < 0) {
-        return;
-      }
-
+      const mcidRaw = this.pdfiumModule.FPDFPageObj_GetMarkedContentID(objPtr);
+      const mcid = mcidRaw >= 0 ? mcidRaw : GLOBAL_MCID;
       const entry = ensureEntry(mcid);
 
       const leftPtr = this.memoryManager.malloc(4);
@@ -8404,11 +8404,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       }
 
       const mcid = this.pdfiumModule.FPDFPageObj_GetMarkedContentID(textObjPtr);
-      if (mcid < 0) {
-        continue;
-      }
-
-      const entry = ensureEntry(mcid);
+      const entry = ensureEntry(mcid >= 0 ? mcid : GLOBAL_MCID);
       const glyph = this.readGlyphInfo(page, pageCtx.pagePtr, textPagePtr, charIndex);
 
       const glyphRect: Rect = {
@@ -8424,7 +8420,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       const runKey = textObjPtr;
       let run = entry.runs.get(runKey);
       if (!run) {
-        run = { text: '', rect: null, matrix: undefined };
+        run = { text: '', rect: null, matrix: undefined, charCount: 0 };
         entry.runs.set(runKey, run);
       }
 
@@ -8440,6 +8436,10 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
             f: this.pdfiumModule.pdfium.getValue(matrixPtr + 20, 'float'),
           };
           run.matrix = matrix;
+          const angle = Math.atan2(matrix.b, matrix.a);
+          if (Number.isFinite(angle)) {
+            run.angle = angle;
+          }
         }
         this.memoryManager.free(matrixPtr);
       }
@@ -8467,6 +8467,8 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       if (!run.font && fontInfo) {
         run.font = fontInfo;
       }
+
+      run.charCount += 1;
 
       const charCode =
         glyph.charCode !== undefined
@@ -8507,6 +8509,18 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
     const getBottom = (run: McidRunAccumulator) =>
       run.pageBottom ?? (run.rect ? run.rect.origin.y : 0);
     const getBaseline = (run: McidRunAccumulator) => getBottom(run);
+    const getAverageWidth = (run: McidRunAccumulator) => {
+      const width = getRight(run) - getLeft(run);
+      if (!Number.isFinite(width) || width <= 0) {
+        return undefined;
+      }
+      const divisor = run.charCount > 0 ? run.charCount : Math.max(run.text.length, 1);
+      if (!divisor) {
+        return undefined;
+      }
+      const avg = width / divisor;
+      return Number.isFinite(avg) && avg > 0 ? avg : undefined;
+    };
 
     const fontsEqual = (a?: PdfStructElementFont, b?: PdfStructElementFont): boolean => {
       if (!a && !b) return true;
@@ -8533,6 +8547,19 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
     const MERGE_Y_THRESHOLD = 0.2;
     const MERGE_BACKTRACK = 0.05;
 
+    const computeGapThreshold = (a: McidRunAccumulator, b: McidRunAccumulator) => {
+      const base = MERGE_GAP_THRESHOLD;
+      const sizeHint = Math.max(a.font?.size ?? 0, b.font?.size ?? 0);
+      const widthHint = Math.max(getAverageWidth(a) ?? 0, getAverageWidth(b) ?? 0);
+      const dynamic = Math.max(sizeHint * 0.25, widthHint * 0.8);
+      return Math.max(base, dynamic);
+    };
+
+    const computeBacktrack = (a: McidRunAccumulator, b: McidRunAccumulator) => {
+      const avg = Math.max(getAverageWidth(a) ?? 0, getAverageWidth(b) ?? 0);
+      return Math.max(MERGE_BACKTRACK, avg * 0.25);
+    };
+
     const cloneAccumulator = (run: McidRunAccumulator): McidRunAccumulator => ({
       text: run.text,
       rect: run.rect ? cloneRect(run.rect) : null,
@@ -8544,6 +8571,8 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       pageBottom: run.pageBottom,
       firstIndex: run.firstIndex,
       lastIndex: run.lastIndex,
+      angle: run.angle,
+      charCount: run.charCount,
     });
 
     const mergeRuns = (runs: McidRunAccumulator[]): McidRunAccumulator[] => {
@@ -8568,36 +8597,42 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       const merged: McidRunAccumulator[] = [];
       for (const current of sorted) {
         const last = merged[merged.length - 1];
-        if (
-          last &&
-          fontsEqual(last.font, current.font) &&
-          Math.abs(getBaseline(last) - getBaseline(current)) <= MERGE_Y_THRESHOLD
-        ) {
-          const gap = getLeft(current) - getRight(last);
-          if (gap >= -MERGE_BACKTRACK && gap <= MERGE_GAP_THRESHOLD) {
-            last.text += current.text;
-            if (last.rect && current.rect) {
-              last.rect = unionRect(last.rect, current.rect);
-            } else if (!last.rect && current.rect) {
-              last.rect = cloneRect(current.rect);
-            }
-            const lastLeft = getLeft(last);
-            const lastRight = getRight(last);
-            const lastTop = getTop(last);
-            const lastBottom = getBottom(last);
-            const currentLeft = getLeft(current);
-            const currentRight = getRight(current);
-            const currentTop = getTop(current);
-            const currentBottom = getBottom(current);
+        if (last) {
+          const sameFont = fontsEqual(last.font, current.font);
+          const sameBaseline =
+            Math.abs(getBaseline(last) - getBaseline(current)) <= MERGE_Y_THRESHOLD;
+          const sameAngle =
+            last.angle === undefined ||
+            current.angle === undefined ||
+            Math.abs(last.angle - current.angle) <= 0.01;
+          if (sameFont && sameBaseline && sameAngle) {
+            const gap = getLeft(current) - getRight(last);
+            const gapThreshold = computeGapThreshold(last, current);
+            const backtrack = computeBacktrack(last, current);
+            if (gap >= -backtrack && gap <= gapThreshold) {
+              last.text += current.text;
+              if (last.rect && current.rect) {
+                last.rect = unionRect(last.rect, current.rect);
+              } else if (!last.rect && current.rect) {
+                last.rect = cloneRect(current.rect);
+              }
+              const lastLeft = getLeft(last);
+              const lastRight = getRight(last);
+              const lastTop = getTop(last);
+              const lastBottom = getBottom(last);
+              const currentLeft = getLeft(current);
+              const currentRight = getRight(current);
+              const currentTop = getTop(current);
+              const currentBottom = getBottom(current);
 
-            last.pageLeft = Math.min(lastLeft, currentLeft);
-            last.pageRight = Math.max(lastRight, currentRight);
-            last.pageTop = Math.max(lastTop, currentTop);
-            last.pageBottom = Math.min(lastBottom, currentBottom);
-            last.firstIndex =
-              last.firstIndex !== undefined && current.firstIndex !== undefined
-                ? Math.min(last.firstIndex, current.firstIndex)
-                : last.firstIndex ?? current.firstIndex;
+              last.pageLeft = Math.min(lastLeft, currentLeft);
+              last.pageRight = Math.max(lastRight, currentRight);
+              last.pageTop = Math.max(lastTop, currentTop);
+              last.pageBottom = Math.min(lastBottom, currentBottom);
+              last.firstIndex =
+                last.firstIndex !== undefined && current.firstIndex !== undefined
+                  ? Math.min(last.firstIndex, current.firstIndex)
+                  : last.firstIndex ?? current.firstIndex;
               last.lastIndex =
                 last.lastIndex !== undefined && current.lastIndex !== undefined
                   ? Math.max(last.lastIndex, current.lastIndex)
@@ -8608,11 +8643,13 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
               if (!last.matrix && current.matrix) {
                 last.matrix = { ...current.matrix };
               }
+              last.charCount += current.charCount;
               continue;
             }
           }
-          merged.push(current);
         }
+        merged.push(current);
+      }
       return merged;
     };
 
@@ -8718,6 +8755,27 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       if (childPtr) {
         elements.push(buildElement(childPtr));
       }
+    }
+
+    const globalInfo = mcidMap.get(GLOBAL_MCID);
+    if (globalInfo && (globalInfo.textRuns.length || globalInfo.text)) {
+      const rect = globalInfo.rect ? cloneRect(globalInfo.rect) : cloneRect(null);
+      elements.push({
+        tag: 'Span',
+        text: globalInfo.text,
+        rect,
+        lang: undefined,
+        attributes: { 'data-untagged': 'true' },
+        font: globalInfo.font ? { ...globalInfo.font } : undefined,
+        textRuns: globalInfo.textRuns.map((run) => ({
+          text: run.text,
+          rect: cloneRect(run.rect),
+          ...(run.font ? { font: { ...run.font } } : {}),
+          ...(run.matrix ? { matrix: { ...run.matrix } } : {}),
+        })),
+        mcids: [],
+        children: [],
+      });
     }
 
     this.pdfiumModule.FPDF_StructTree_Close(treePtr);

--- a/packages/engines/src/lib/pdfium/engine.ts
+++ b/packages/engines/src/lib/pdfium/engine.ts
@@ -3789,9 +3789,9 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
   /**
    * Extract glyph geometry + metadata for `charIndex`
    *
-   * Returns device–space coordinates:
-   *   x,y  → **top-left** corner (integer-pixels)
-   *   w,h  → width / height (integer-pixels, ≥ 1)
+   * Returns page-user-space coordinates (points) with an origin at the page's top-left:
+   *   x,y  → top-left corner
+   *   w,h  → width / height
    *
    * And two flags:
    *   isSpace → true if the glyph's Unicode code-point is U+0020
@@ -3802,11 +3802,6 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
     textPagePtr: number,
     charIndex: number,
   ): PdfGlyphObject {
-    // ── native stack temp pointers ──────────────────────────────
-    const dx1Ptr = this.memoryManager.malloc(4);
-    const dy1Ptr = this.memoryManager.malloc(4);
-    const dx2Ptr = this.memoryManager.malloc(4);
-    const dy2Ptr = this.memoryManager.malloc(4);
     const rectPtr = this.memoryManager.malloc(16); // 4 floats = 16 bytes
 
     let x = 0,
@@ -3834,61 +3829,35 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       const maxX = Math.max(left, right);
       const minY = Math.min(top, bottom);
       const maxY = Math.max(top, bottom);
-      pageBounds = { left: minX, right: maxX, top: maxY, bottom: minY };
+      const rawWidth = maxX - minX;
+      const rawHeight = maxY - minY;
 
-      if (left === right || top === bottom) {
-        [rectPtr, dx1Ptr, dy1Ptr, dx2Ptr, dy2Ptr].forEach((p) => this.memoryManager.free(p));
+      if (!Number.isFinite(rawWidth) || !Number.isFinite(rawHeight) || rawWidth <= 0 || rawHeight <= 0) {
+        this.memoryManager.free(rectPtr);
 
         return {
           origin: { x: 0, y: 0 },
           size: { width: 0, height: 0 },
           isEmpty: true,
           ...(charCode !== undefined && { charCode }),
-          ...(pageBounds ? { pageBounds } : {}),
         };
       }
 
-      // ── 2) map 2 opposite corners to            device-space
-      this.pdfiumModule.FPDF_PageToDevice(
-        pagePtr,
-        0,
-        0,
-        page.size.width,
-        page.size.height,
-        /*rotate=*/ 0,
-        left,
-        top,
-        dx1Ptr,
-        dy1Ptr,
-      );
-      this.pdfiumModule.FPDF_PageToDevice(
-        pagePtr,
-        0,
-        0,
-        page.size.width,
-        page.size.height,
-        /*rotate=*/ 0,
-        right,
-        bottom,
-        dx2Ptr,
-        dy2Ptr,
-      );
+      const declaredPageHeight = Number.isFinite(page.size.height) ? page.size.height : 0;
+      const pageHeight = declaredPageHeight > 0 ? Math.max(declaredPageHeight, maxY) : maxY;
+      const topY = pageHeight - maxY;
+      const bottomY = topY + rawHeight;
 
-      const x1 = this.pdfiumModule.pdfium.getValue(dx1Ptr, 'i32');
-      const y1 = this.pdfiumModule.pdfium.getValue(dy1Ptr, 'i32');
-      const x2 = this.pdfiumModule.pdfium.getValue(dx2Ptr, 'i32');
-      const y2 = this.pdfiumModule.pdfium.getValue(dy2Ptr, 'i32');
+      pageBounds = { left: minX, right: maxX, top: topY, bottom: bottomY };
 
-      x = Math.min(x1, x2);
-      y = Math.min(y1, y2);
-      width = Math.max(1, Math.abs(x2 - x1));
-      height = Math.max(1, Math.abs(y2 - y1));
-
-      // ── 3) extra flags ───────────────────────────────────────
+      x = minX;
+      y = topY;
+      width = rawWidth;
+      height = rawHeight;
     }
 
     // ── free tmps ───────────────────────────────────────────────
-    [rectPtr, dx1Ptr, dy1Ptr, dx2Ptr, dy2Ptr].forEach((p) => this.memoryManager.free(p));
+    this.memoryManager.free(rectPtr);
 
     return {
       origin: { x, y },
@@ -8457,8 +8426,8 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
         const { left, right, top, bottom } = bounds;
         run.pageLeft = run.pageLeft === undefined ? left : Math.min(run.pageLeft, left);
         run.pageRight = run.pageRight === undefined ? right : Math.max(run.pageRight, right);
-        run.pageTop = run.pageTop === undefined ? top : Math.max(run.pageTop, top);
-        run.pageBottom = run.pageBottom === undefined ? bottom : Math.min(run.pageBottom, bottom);
+        run.pageTop = run.pageTop === undefined ? top : Math.min(run.pageTop, top);
+        run.pageBottom = run.pageBottom === undefined ? bottom : Math.max(run.pageBottom, bottom);
       }
 
       run.firstIndex =
@@ -8503,10 +8472,10 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
     const getLeft = (run: McidRunAccumulator) => run.pageLeft ?? (run.rect ? run.rect.origin.x : 0);
     const getRight = (run: McidRunAccumulator) =>
       run.pageRight ?? (run.rect ? run.rect.origin.x + run.rect.size.width : getLeft(run));
-    const getTop = (run: McidRunAccumulator) =>
-      run.pageTop ?? (run.rect ? run.rect.origin.y + run.rect.size.height : 0);
+    const getTop = (run: McidRunAccumulator) => run.pageTop ?? (run.rect ? run.rect.origin.y : 0);
     const getBottom = (run: McidRunAccumulator) =>
-      run.pageBottom ?? (run.rect ? run.rect.origin.y : 0);
+      run.pageBottom ??
+      (run.rect ? run.rect.origin.y + run.rect.size.height : getTop(run));
     const getBaseline = (run: McidRunAccumulator) => getBottom(run);
     const getAverageWidth = (run: McidRunAccumulator) => {
       const width = getRight(run) - getLeft(run);
@@ -8697,8 +8666,8 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
 
               last.pageLeft = Math.min(lastLeft, currentLeft);
               last.pageRight = Math.max(lastRight, currentRight);
-              last.pageTop = Math.max(lastTop, currentTop);
-              last.pageBottom = Math.min(lastBottom, currentBottom);
+              last.pageTop = Math.min(lastTop, currentTop);
+              last.pageBottom = Math.max(lastBottom, currentBottom);
               last.firstIndex =
                 last.firstIndex !== undefined && current.firstIndex !== undefined
                   ? Math.min(last.firstIndex, current.firstIndex)

--- a/packages/engines/src/lib/pdfium/engine.ts
+++ b/packages/engines/src/lib/pdfium/engine.ts
@@ -8767,6 +8767,9 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       const seen = new Set<number>();
       for (let i = 0; i < mcidCount; i++) {
         const mcid = this.pdfiumModule.FPDF_StructElement_GetMarkedContentIdAtIndex(elPtr, i);
+        if (mcid < 0) {
+          continue;
+        }
         if (seen.has(mcid)) {
           continue;
         }

--- a/packages/engines/src/lib/pdfium/engine.ts
+++ b/packages/engines/src/lib/pdfium/engine.ts
@@ -8339,9 +8339,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
           height: Math.max(1, Math.abs(y2 - y1)),
         },
       };
-
       entry.rect = entry.rect ? unionRect(entry.rect, rect) : rect;
-
     };
 
     const objectCount = this.pdfiumModule.FPDFPage_CountObjects(pageCtx.pagePtr);
@@ -8353,7 +8351,13 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
     const readFontInfo = (charIndex: number): PdfStructElementFont | undefined => {
       let family: string | undefined;
       let flags: number | undefined;
-      const fontNameLength = this.pdfiumModule.FPDFText_GetFontInfo(textPagePtr, charIndex, 0, 0, 0);
+      const fontNameLength = this.pdfiumModule.FPDFText_GetFontInfo(
+        textPagePtr,
+        charIndex,
+        0,
+        0,
+        0,
+      );
       if (fontNameLength > 0) {
         const bytes = fontNameLength + 1; // include NIL
         const textBufferPtr = this.memoryManager.malloc(bytes);
@@ -8378,7 +8382,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
 
       const ITALIC_FLAGS = 0x20 | 0x40;
       const FORCE_BOLD_FLAG = 0x100;
-      const italic = !!(flags && (flags & ITALIC_FLAGS));
+      const italic = !!(flags && flags & ITALIC_FLAGS);
       if (flags && flags & FORCE_BOLD_FLAG) {
         fontWeight = Math.max(fontWeight ?? 600, 600);
       }
@@ -8454,11 +8458,11 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
         run.pageLeft = run.pageLeft === undefined ? left : Math.min(run.pageLeft, left);
         run.pageRight = run.pageRight === undefined ? right : Math.max(run.pageRight, right);
         run.pageTop = run.pageTop === undefined ? top : Math.max(run.pageTop, top);
-        run.pageBottom =
-          run.pageBottom === undefined ? bottom : Math.min(run.pageBottom, bottom);
+        run.pageBottom = run.pageBottom === undefined ? bottom : Math.min(run.pageBottom, bottom);
       }
 
-      run.firstIndex = run.firstIndex === undefined ? charIndex : Math.min(run.firstIndex, charIndex);
+      run.firstIndex =
+        run.firstIndex === undefined ? charIndex : Math.min(run.firstIndex, charIndex);
       run.lastIndex = run.lastIndex === undefined ? charIndex : Math.max(run.lastIndex, charIndex);
 
       if (!entry.font && fontInfo) {
@@ -8475,11 +8479,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
           ? glyph.charCode
           : this.pdfiumModule.FPDFText_GetUnicode(textPagePtr, charIndex);
       const char =
-        charCode && charCode > 0
-          ? String.fromCodePoint(charCode)
-          : glyph.isSpace
-          ? ' '
-          : '';
+        charCode && charCode > 0 ? String.fromCodePoint(charCode) : glyph.isSpace ? ' ' : '';
 
       if (char) {
         entry.text += char;
@@ -8500,8 +8500,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       };
     };
 
-    const getLeft = (run: McidRunAccumulator) =>
-      run.pageLeft ?? (run.rect ? run.rect.origin.x : 0);
+    const getLeft = (run: McidRunAccumulator) => run.pageLeft ?? (run.rect ? run.rect.origin.x : 0);
     const getRight = (run: McidRunAccumulator) =>
       run.pageRight ?? (run.rect ? run.rect.origin.x + run.rect.size.width : getLeft(run));
     const getTop = (run: McidRunAccumulator) =>
@@ -8546,6 +8545,67 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
     const MERGE_GAP_THRESHOLD = 0.2;
     const MERGE_Y_THRESHOLD = 0.2;
     const MERGE_BACKTRACK = 0.05;
+
+    const TRACKING_SPACE_FACTOR = 0.102;
+    const NOT_A_SPACE_FACTOR = 0.03;
+    const SPACE_IN_FLOW_MIN_FACTOR = 0.102;
+    const SPACE_IN_FLOW_MAX_FACTOR = 0.6;
+
+    const getFontSizeHint = (run: McidRunAccumulator) => {
+      const fontSize = run.font?.size;
+      if (fontSize !== undefined && Number.isFinite(fontSize) && fontSize > 0) {
+        return fontSize;
+      }
+      const rectHeight = run.rect?.size.height;
+      if (rectHeight !== undefined && Number.isFinite(rectHeight) && rectHeight > 0) {
+        return rectHeight;
+      }
+      const avgWidth = getAverageWidth(run);
+      return avgWidth ?? undefined;
+    };
+
+    const evaluateSpacing = (
+      last: McidRunAccumulator,
+      current: McidRunAccumulator,
+      gap: number,
+    ): 'merge' | 'mergeWithSpace' | 'break' => {
+      if (!Number.isFinite(gap) || gap <= 0) {
+        return 'merge';
+      }
+
+      if (last.text.endsWith(' ') || current.text.startsWith(' ')) {
+        return 'merge';
+      }
+
+      const fontSize = Math.max(getFontSizeHint(last) ?? 0, getFontSizeHint(current) ?? 0);
+
+      if (!fontSize || !Number.isFinite(fontSize)) {
+        return gap > MERGE_GAP_THRESHOLD ? 'break' : 'merge';
+      }
+
+      const notASpace = fontSize * NOT_A_SPACE_FACTOR;
+      if (gap <= notASpace) {
+        return 'merge';
+      }
+
+      const trackingSpace = fontSize * TRACKING_SPACE_FACTOR;
+      if (gap <= trackingSpace) {
+        return 'merge';
+      }
+
+      const spaceMin = fontSize * SPACE_IN_FLOW_MIN_FACTOR;
+      const spaceMax = fontSize * SPACE_IN_FLOW_MAX_FACTOR;
+
+      if (gap >= spaceMin && gap <= spaceMax) {
+        return 'mergeWithSpace';
+      }
+
+      if (gap > spaceMax) {
+        return 'break';
+      }
+
+      return 'merge';
+    };
 
     const computeGapThreshold = (a: McidRunAccumulator, b: McidRunAccumulator) => {
       const base = MERGE_GAP_THRESHOLD;
@@ -8610,6 +8670,16 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
             const gapThreshold = computeGapThreshold(last, current);
             const backtrack = computeBacktrack(last, current);
             if (gap >= -backtrack && gap <= gapThreshold) {
+              const spacingDecision = evaluateSpacing(last, current, gap);
+              if (spacingDecision === 'break') {
+                merged.push(current);
+                continue;
+              }
+
+              if (spacingDecision === 'mergeWithSpace') {
+                last.text += ' ';
+              }
+
               last.text += current.text;
               if (last.rect && current.rect) {
                 last.rect = unionRect(last.rect, current.rect);
@@ -8632,11 +8702,11 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
               last.firstIndex =
                 last.firstIndex !== undefined && current.firstIndex !== undefined
                   ? Math.min(last.firstIndex, current.firstIndex)
-                  : last.firstIndex ?? current.firstIndex;
+                  : (last.firstIndex ?? current.firstIndex);
               last.lastIndex =
                 last.lastIndex !== undefined && current.lastIndex !== undefined
                   ? Math.max(last.lastIndex, current.lastIndex)
-                  : last.lastIndex ?? current.lastIndex;
+                  : (last.lastIndex ?? current.lastIndex);
               if (!last.font && current.font) {
                 last.font = { ...current.font };
               }

--- a/packages/models/src/pdf.ts
+++ b/packages/models/src/pdf.ts
@@ -2307,7 +2307,7 @@ export interface PdfGlyphObject {
    */
   charCode?: number;
   /**
-   * Bounding box of the glyph in page-user-space coordinates
+   * Bounding box of the glyph in page-user-space coordinates (origin at top/left)
    */
   pageBounds?: { left: number; right: number; top: number; bottom: number };
 }

--- a/packages/plugin-a11y/src/lib/a11y-plugin.ts
+++ b/packages/plugin-a11y/src/lib/a11y-plugin.ts
@@ -7,7 +7,7 @@ import {
   StructElementFont,
   StructElementTextRun,
 } from './types';
-import { mapPdfTagToHtml } from './utils';
+import { mapPdfTagToHtml, A11yLayerClassName } from './utils';
 
 export class A11yPlugin extends BasePlugin<A11yPluginConfig, A11yCapability> {
   static readonly id = 'a11y' as const;
@@ -26,13 +26,18 @@ export class A11yPlugin extends BasePlugin<A11yPluginConfig, A11yCapability> {
     return {
       getStructElements: this.getStructElements.bind(this),
       getClassNames: this.getClassNames.bind(this),
+      getDebugState: this.getDebugState.bind(this),
     };
   }
 
+  private getDebugState(): boolean{
+    return this.config.debug || false;
+  };
+
   private getClassNames(): string {
-    const classes = ['embedpdf-a11y-layer'];
+    const classes = [A11yLayerClassName];
     if (this.config.debug) {
-      classes.push('embedpdf-a11y-debug');
+      classes.push('debug');
     }
     return classes.join(' ');
   }

--- a/packages/plugin-a11y/src/lib/a11y-plugin.ts
+++ b/packages/plugin-a11y/src/lib/a11y-plugin.ts
@@ -117,13 +117,16 @@ export class A11yPlugin extends BasePlugin<A11yPluginConfig, A11yCapability> {
           })
         : [];
 
+      const [htmlTag, htmlRole] = mapPdfTagToHtml(el.tag);
+      const attributes = {... el.attributes, htmlRole };
+
       return {
         tag: el.tag,
-        htmlTag: mapPdfTagToHtml(el.tag),
+        htmlTag,
         text: typeof el.text === 'string' ? el.text : '',
         rect: cloneRect(el.rect),
         language: el.lang,
-        attributes: el.attributes || {},
+        attributes,
         font: mapFont(el.font),
         textRuns,
         mcids: Array.isArray(el.mcids) ? el.mcids : [],

--- a/packages/plugin-a11y/src/lib/types.ts
+++ b/packages/plugin-a11y/src/lib/types.ts
@@ -35,6 +35,7 @@ export interface A11yPluginConfig {
 export interface A11yCapability {
   getStructElements: (pageIndex: number) => Promise<StructElement[]>;
   getClassNames: () => string;
+  getDebugState: () => boolean;
 }
 
 export interface A11yState {}

--- a/packages/plugin-a11y/src/lib/utils.ts
+++ b/packages/plugin-a11y/src/lib/utils.ts
@@ -1,30 +1,36 @@
-const TAG_MAP: Record<string, string> = {
-  Document: "section",
-  Part: "section",
-  Sect: "section",
-  Div: "div",
-  P: "p",
-  Span: "span",
-  H: "h1",
-  H1: "h1",
-  H2: "h2",
-  H3: "h3",
-  H4: "h4",
-  H5: "h5",
-  H6: "h6",
-  L: "ul",
-  LI: "li",
-  LBody: "ul",
-  Table: "table",
-  TR: "tr",
-  TH: "th",
-  TD: "td",
-  Figure: "figure",
-  Caption: "figcaption",
+const TAG_MAP: Record<string, [string, string?]> = {
+  Document: ["article" , "document"],
+  Part: ["section"],
+  Sect: ["section"],
+  Div: ["div"],
+  P: ["p"],
+  Span: ["span"],
+  H: ["div", "heading"],
+  H1: ["h1"],
+  H2: ["h2"],
+  H3: ["h3"],
+  H4: ["h4"],
+  H5: ["h5"],
+  H6: ["h6"],
+  L: ["ul"],
+  LI: ["li"],
+  LBody: ["div"],
+  Table: ["table"],
+  TR: ["tr"],
+  TH: ["th"],
+  TD: ["td"],
+  Caption: ["figcaption"],
+  BlockQuote: ["blockquote"],
+  Header: ["header"],
+  Footer: ["footer"],
+  Note: ["aside", "note"],     
+  Formula: ["span", "math"],   
+  Figure: ["figure", "figure"],
+  NonStruct: ["span", "presentation"]
 };
 
-export function mapPdfTagToHtml(tag: string): string {
-  return TAG_MAP[tag] ?? "span";
+export function mapPdfTagToHtml(tag: string): [string, string?] {
+  return TAG_MAP[tag] ?? ["span"];
 }
 
 export const A11yLayerClassName = "embedpdf-a11y-layer";
@@ -76,13 +82,29 @@ styleSheet.replaceSync(`
 
 export function translateFontFamily(fontFamily: string | undefined): string | undefined {
   if (!fontFamily) return undefined;
+  let fontFamilies = new Set([fontFamily]);
+  let category= "sans-serif";
   if (fontFamily.includes("-")) {
-    return `${fontFamily}, ${fontFamily.split("-")[0]}, sans-serif`;
+    fontFamilies.add(fontFamily.split("-")[0]);
   }
-  if (fontFamily.includes("Helvetica")) return "Helvetica, Arial, sans-serif";
-  if (fontFamily.includes("Times")) return "Times New Roman, serif";
-  if (fontFamily.includes("Courier")) return "Courier New, monospace";
-  return fontFamily;
+  if (fontFamily.includes("+")) {
+    fontFamilies.add(fontFamily.split("+")[1]);
+  }
+  if (fontFamily.includes("Arial") || fontFamily.includes("Helvetica")) {
+    fontFamilies.add("Arial");
+    fontFamilies.add("Helvetica");
+  }
+  if (fontFamily.includes("Times") || fontFamily.includes("Roman")) {
+    fontFamilies.add("Times New Roman");
+    fontFamilies.add("Times");
+    category = "serif";
+  }
+  if (fontFamily.includes("Courier")) {
+    fontFamilies.add("Courier New");
+    fontFamilies.add("Courier");
+    category = "monospace";
+  } 
+  return Array.from(fontFamilies).join(", ") + `, ${category}`;
 }
 
 const fontClassNameMap: Map<string, string> = new Map();

--- a/packages/plugin-a11y/src/lib/utils.ts
+++ b/packages/plugin-a11y/src/lib/utils.ts
@@ -30,21 +30,35 @@ export function mapPdfTagToHtml(tag: string): string {
 export const A11yLayerClassName = "embedpdf-a11y-layer";
 const styleSheet = new CSSStyleSheet();
 styleSheet.replaceSync(`
-  .${A11yLayerClassName}, .${A11yLayerClassName} * {
+  .${A11yLayerClassName} {
     pointer-events: none;
     position: absolute;
     top: 0;
     left: 0;
+    color: #0000;
     font-family: Sans-Serif;
-  }
-  .${A11yLayerClassName} * {
-    white-space: pre;
-    font-kerning: none;
-  }
-  .${A11yLayerClassName} .textrun {
-    overflow: visible;
-    display: inline-block;
-    overflow: hidden;
+    font-size: 0;
+
+    &.debug {
+      color: hotpink;
+      z-index: 1000;
+    }
+
+    * {
+      position: absolute;
+      white-space: pre;
+      font-kerning: none;
+      top: 0;
+      left: 0;
+      color: inherit;
+      font: inherit;
+    }
+
+    .textrun {
+      overflow: visible;
+      display: inline-block;
+      overflow: hidden;
+    }
   }
 `);
 

--- a/packages/plugin-a11y/src/lib/utils.ts
+++ b/packages/plugin-a11y/src/lib/utils.ts
@@ -42,6 +42,17 @@ styleSheet.replaceSync(`
     &.debug {
       color: hotpink;
       z-index: 1000;
+
+      [data-pdftag]::before {
+        content: attr(data-pdftag, "");
+        position: absolute;
+        display: inline-block;
+        top: -.7rem;
+        font-size: .7rem;
+        left: 0;
+        background: #b6b6b675;
+        color: hotpink;
+      }
     }
 
     * {
@@ -58,6 +69,7 @@ styleSheet.replaceSync(`
       overflow: visible;
       display: inline-block;
       overflow: hidden;
+      transform-origin: 0% 0%;
     }
   }
 `);

--- a/packages/plugin-a11y/src/shared/components/a11y-layer.tsx
+++ b/packages/plugin-a11y/src/shared/components/a11y-layer.tsx
@@ -13,6 +13,7 @@ type Props = {
 export function A11yLayer({ pageIndex, scale }: Props) {
   const { provides } = useA11yCapability();
   const [className, setClassName] = useState<string>(A11yLayerClassName); 
+  const [debug, setDebug] = useState<boolean>(false); 
   const [elements, setElements] = useState<StructElementModel[]>([]);
   const layerRef = useRef<HTMLDivElement>(null);
 
@@ -23,6 +24,7 @@ export function A11yLayer({ pageIndex, scale }: Props) {
       .then(setElements)
       .catch(() => setElements([]));
     setClassName(provides.getClassNames());
+    setDebug(provides.getDebugState());
   }, [provides, pageIndex]);
 
   useEffect(() => {
@@ -40,9 +42,9 @@ export function A11yLayer({ pageIndex, scale }: Props) {
   };
 
   return (
-    <div className={className} ref={layerRef} style={style}>
+    <div className={className} ref={layerRef} style={style as any}>
       {elements.map((el, i) => (
-        <StructElementComponent key={i} element={el} scale={scale} />
+        <StructElementComponent key={i} element={el} scale={scale} debug={debug}/>
       ))}
     </div>
   );

--- a/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
+++ b/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
@@ -7,12 +7,13 @@ interface Props {
   element: StructElementModel;
   scale: number;
   parentLanguage?: string;
+  debug: boolean;
 }
 
-export function StructElementComponent({ element, scale, parentLanguage }: Props) {
+export function StructElementComponent({ element, scale, parentLanguage, debug }: Props) {
   const elementRef = useRef<HTMLElement>(null);
 
-  const viewModel = computeStructElementViewModel(element, scale, parentLanguage);
+  const viewModel = computeStructElementViewModel(element, scale, parentLanguage, debug);
   const Tag = viewModel.tagName as any;
 
   useEffect(() => {
@@ -39,6 +40,7 @@ export function StructElementComponent({ element, scale, parentLanguage }: Props
           element={child}
           scale={scale}
           parentLanguage={viewModel.nextParentLanguage}
+          debug={debug}
         />
       ))}
     </Tag>

--- a/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
+++ b/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
@@ -1,5 +1,5 @@
 import type { StructElement as StructElementModel } from '@embedpdf/plugin-a11y';
-import { useEffect, useRef } from 'react';
+import { Fragment, useEffect, useRef } from 'react';
 import { computeStructElementViewModel } from './struct-element-viewmodel';
 import { A11yLayerClassName } from '../../lib/utils';
 
@@ -25,15 +25,12 @@ export function StructElementComponent({ element, scale, parentLanguage, debug }
   return (
     <Tag {...viewModel.attrs} style={viewModel.elementStyle} ref={elementRef}>
       {viewModel.textRuns.map((run, i) => (
-        <span
-          key={i}
-          className={run.className}
-          style={run.style}
-          role="presentation"
-        >
-          {run.text}
-          {run.text.match(/[\n\r]+/) ? <br role="presentation" /> : null}
-        </span>
+        <Fragment key={i}>
+          {run.breakBefore ? <br role="presentation" /> : null}
+          <span className={run.className} style={run.style} role="presentation">
+            {run.text}
+          </span>
+        </Fragment>
       ))}
       {element.children.map((child, i) => (
         <StructElementComponent

--- a/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
+++ b/packages/plugin-a11y/src/shared/components/struct-element-component.tsx
@@ -23,7 +23,7 @@ export function StructElementComponent({ element, scale, parentLanguage, debug }
   });
 
   return (
-    <Tag {...viewModel.attrs} style={viewModel.elementStyle} data-pdftag={element.tag} ref={elementRef}>
+    <Tag {...viewModel.attrs} style={viewModel.elementStyle} ref={elementRef}>
       {viewModel.textRuns.map((run, i) => (
         <span
           key={i}
@@ -32,6 +32,7 @@ export function StructElementComponent({ element, scale, parentLanguage, debug }
           role="presentation"
         >
           {run.text}
+          {run.text.match(/[\n\r]+/) ? <br role="presentation" /> : null}
         </span>
       ))}
       {element.children.map((child, i) => (

--- a/packages/plugin-a11y/src/shared/components/struct-element-viewmodel.ts
+++ b/packages/plugin-a11y/src/shared/components/struct-element-viewmodel.ts
@@ -201,7 +201,7 @@ export function computeStructElementViewModel(
       style: {
         left: toOptionalNumber(relativeLeft),
         top: toOptionalNumber(relativeTop),
-        ...(transform ? { transform, transformOrigin: 'top left' } : {}),
+        ...(transform ? { transform } : {}),
       },
     };
   });

--- a/packages/plugin-a11y/src/shared/components/struct-element-viewmodel.ts
+++ b/packages/plugin-a11y/src/shared/components/struct-element-viewmodel.ts
@@ -92,6 +92,7 @@ export function computeStructElementViewModel(
   element: StructElement,
   scale: number,
   parentLanguage?: string,
+  debug: boolean = false,
 ): StructElementViewModel {
   // All geometry in the struct tree is in page-user units (points) where the
   // origin sits at the top/left of the page. Every time we project something
@@ -109,9 +110,15 @@ export function computeStructElementViewModel(
     height: toOptionalNumber(multiplySafe(element.rect.size.height, scale)),
   };
 
+  const attrs: Record<string, string> = { ...(element.attributes ?? {}) };
+
+  // If we're in debug mode, add a attrbiute to see original struct type
+  if (debug) {
+    attrs['data-pdftag'] = element.tag;
+  }
+
   // Forward language/attributes down the tree; the viewer uses this for
   // screen readers and inspectors.
-  const attrs: Record<string, string> = { ...(element.attributes ?? {}) };
   const ownLanguage = element.language;
   if (ownLanguage && ownLanguage !== parentLanguage) {
     attrs.lang = ownLanguage;

--- a/packages/plugin-a11y/src/shared/components/struct-element-viewmodel.ts
+++ b/packages/plugin-a11y/src/shared/components/struct-element-viewmodel.ts
@@ -11,6 +11,7 @@ export interface StructElementRunViewModel {
     transform?: string;
     transformOrigin?: string;
   };
+  breakBefore?: boolean;
 }
 
 export interface StructElementViewModel {
@@ -29,7 +30,8 @@ export interface StructElementViewModel {
 
 const PRECISION = 0.01;
 const MAX_REASONABLE_FONT = 1e4;
-const SPACE_GAP_THRESHOLD = 0.5;
+const SPACE_GAP_THRESHOLD = 0.8;
+const LINE_BREAK_THRESHOLD = 1.5;
 
 const roundTo = (value: number, step: number = PRECISION) =>
   Math.round(value / step) * step;
@@ -140,7 +142,18 @@ export function computeStructElementViewModel(
       : 0;
   const avgTextHeight = avgTextHeightRaw > 0 ? roundTo(avgTextHeightRaw) : 0;
 
-  const textRuns = element.textRuns.map((run, index, runs): StructElementRunViewModel => {
+  const textRuns: StructElementRunViewModel[] = [];
+  let previousRun: StructElementTextRun | undefined;
+
+  for (let index = 0; index < element.textRuns.length; index++) {
+    const run = element.textRuns[index];
+    const baselineDelta =
+      previousRun !== undefined
+        ? Math.abs(run.rect.origin.y - previousRun.rect.origin.y)
+        : 0;
+    const sameLine = previousRun === undefined || baselineDelta <= LINE_BREAK_THRESHOLD;
+    const breakBefore = previousRun !== undefined && !sameLine;
+
     // `fontHeight` is always the rendered height in page-user units. It
     // prefers the text matrix (if available), multiplied by the declared
     // font size (`Tf`), so it stays in sync with the canvas output.
@@ -182,20 +195,25 @@ export function computeStructElementViewModel(
       run.font?.weight ?? element.font?.weight,
       run.font?.italic ?? element.font?.italic,
     );
+
     let displayText = rawText;
     if (displayText) {
-      const prev = index > 0 ? runs[index - 1] : undefined;
-      if (prev && !(prev.text ?? '').endsWith(' ') && !displayText.startsWith(' ')) {
+      const prev = previousRun;
+      if (
+        prev &&
+        sameLine &&
+        !(prev.text ?? '').endsWith(' ') &&
+        !displayText.startsWith(' ')
+      ) {
         const prevRight = prev.rect.origin.x + prev.rect.size.width;
         const gap = run.rect.origin.x - prevRight;
-        const sameLine = Math.abs(run.rect.origin.y - prev.rect.origin.y) <= 0.5;
-        if (sameLine && gap > SPACE_GAP_THRESHOLD) {
+        if (gap > SPACE_GAP_THRESHOLD) {
           displayText = ` ${displayText}`;
         }
       }
     }
 
-    return {
+    textRuns.push({
       text: displayText,
       className: [fontClass, lineHeightClass, 'textrun'].filter(Boolean).join(' '),
       style: {
@@ -203,8 +221,11 @@ export function computeStructElementViewModel(
         top: toOptionalNumber(relativeTop),
         ...(transform ? { transform } : {}),
       },
-    };
-  });
+      ...(breakBefore ? { breakBefore: true } : {}),
+    });
+
+    previousRun = run;
+  }
 
   return {
     tagName,

--- a/packages/plugin-a11y/src/vue/components/a11y-layer.vue
+++ b/packages/plugin-a11y/src/vue/components/a11y-layer.vue
@@ -9,6 +9,7 @@ const props = defineProps<{ pageIndex: number; scale: number }>();
 const { pageIndex, scale } = toRefs(props);
 
 const { provides } = useA11yCapability();
+const debug = ref<boolean>(false);
 const elements = ref<StructElement[]>([]);
 const layerRef = useTemplateRef('layer');
 
@@ -21,6 +22,7 @@ watchEffect(() => {
     .getStructElements(pageIndex.value)
     .then((els) => (elements.value = els))
     .catch(() => (elements.value = []));
+  debug.value = provides.value.getDebugState();
 
   if (layerRef.value != null) {
     const rootNode = layerRef.value.getRootNode();
@@ -43,6 +45,7 @@ watchEffect(() => {
       :key="i"
       :element="el"
       :scale="scale"
+      :debug="debug"
     />
   </div>
 </template>

--- a/packages/plugin-a11y/src/vue/components/struct-element-component.vue
+++ b/packages/plugin-a11y/src/vue/components/struct-element-component.vue
@@ -35,7 +35,6 @@ onMounted(() => {
     :is="tagName"
     v-bind="viewModel.attrs"
     :style="viewModel.elementStyle"
-    :data-pdftag="element.tag"
     ref="rootEl"
   >
     <span

--- a/packages/plugin-a11y/src/vue/components/struct-element-component.vue
+++ b/packages/plugin-a11y/src/vue/components/struct-element-component.vue
@@ -37,15 +37,16 @@ onMounted(() => {
     :style="viewModel.elementStyle"
     ref="rootEl"
   >
-    <span
-      v-for="(run, i) in runs"
-      :key="i"
-      :class="run.className"
-      :style="run.style"
-      role="presentation"
-    >
-      {{ run.text }}
-    </span>
+    <template v-for="(run, i) in runs" :key="i">
+      <br v-if="run.breakBefore" role="presentation" />
+      <span
+        :class="run.className"
+        :style="run.style"
+        role="presentation"
+      >
+        {{ run.text }}
+      </span>
+    </template>
     <StructElementComponent
       v-for="(child, index) in element.children"
       :key="index"

--- a/packages/plugin-a11y/src/vue/components/struct-element-component.vue
+++ b/packages/plugin-a11y/src/vue/components/struct-element-component.vue
@@ -10,11 +10,12 @@ const props = defineProps<{
   element: StructElement;
   scale: number;
   parentLang?: string;
+  debug?: boolean;
 }>();
-const { element, scale, parentLang } = toRefs(props);
+const { element, scale, parentLang, debug } = toRefs(props);
 
 const viewModel = computed(() =>
-  computeStructElementViewModel(element.value, scale.value, parentLang.value),
+  computeStructElementViewModel(element.value, scale.value, parentLang.value, debug.value ?? false),
 );
 
 const tagName = computed(() => viewModel.value.tagName as any);const runs = computed(() => viewModel.value.textRuns);
@@ -52,6 +53,7 @@ onMounted(() => {
       :element="child"
       :scale="scale"
       :parent-lang="nextParentLang"
+      :debug="debug"
     />
   </component>
 </template>

--- a/snippet/src/components/app.tsx
+++ b/snippet/src/components/app.tsx
@@ -2871,7 +2871,7 @@ export function PDFViewer({ config }: PDFViewerProps) {
           createPluginRegistration(RotatePluginPackage, pluginConfigs.rotate),
           createPluginRegistration(SearchPluginPackage),
           createPluginRegistration(SelectionPluginPackage),
-          createPluginRegistration(A11yPluginPackage),
+          createPluginRegistration(A11yPluginPackage, {debug: true}),
           createPluginRegistration(TilingPluginPackage, pluginConfigs.tiling),
           createPluginRegistration(ThumbnailPluginPackage, pluginConfigs.thumbnail),
           createPluginRegistration(AnnotationPluginPackage),


### PR DESCRIPTION
## Summary
- record additional run metrics (angles, character counts) and use dynamic spacing heuristics when merging Pdfium text runs so the a11y overlay matches PDF.js behaviour more closely
- capture marked-content IDs below zero to surface untagged text and append a synthetic span for the page's orphaned content when present

## Testing
- `pnpm --filter @embedpdf/engines lint` *(fails: legacy lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68fa2b2a09a0832dbfee4c6d4c30f55b