### PR TITLE
feat: load embedded fonts for accessibility layer

### DIFF
--- a/packages/engines/src/lib/mock/index.ts
+++ b/packages/engines/src/lib/mock/index.ts
@@ -39,6 +39,7 @@ import {
   PdfPrintOptions,
   PdfTrappedStatus,
   PdfAddAttachmentParams,
+  PdfDocumentEmbeddedFont,
 } from '@embedpdf/models';
 
 /**
@@ -79,6 +80,9 @@ export function createMockPdfEngine(partialEngine?: Partial<PdfEngine>): PdfEngi
     getDocUserPermissions: (doc: PdfDocumentObject) => {
       return PdfTaskHelper.resolve(0xffffffff);
     },
+    getDocumentEmbeddedFonts: jest.fn((doc: PdfDocumentObject) => {
+      return PdfTaskHelper.resolve([] as PdfDocumentEmbeddedFont[]);
+    }),
     getSignatures: (doc: PdfDocumentObject) => {
       const signatures: PdfSignatureObject[] = [];
       return PdfTaskHelper.resolve(signatures);

--- a/packages/engines/src/lib/pdfium/engine.ts
+++ b/packages/engines/src/lib/pdfium/engine.ts
@@ -71,6 +71,7 @@ import {
   PdfGlyphObject,
   PdfPageGeometry,
   PdfStructElement,
+  PdfDocumentEmbeddedFont,
   PdfStructElementFont,
   PdfStructElementTextRun,
   PdfTextMatrix,
@@ -8191,6 +8192,171 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
   }
 
   /**
+   * Extract all embedded fonts from the document for accessibility layer usage.
+   */
+  getDocumentEmbeddedFonts(doc: PdfDocumentObject): PdfTask<PdfDocumentEmbeddedFont[]> {
+    this.logger.debug(LOG_SOURCE, LOG_CATEGORY, 'getDocumentEmbeddedFonts', doc);
+
+    const ctx = this.cache.getContext(doc.id);
+    if (!ctx) {
+      return PdfTaskHelper.resolve<PdfDocumentEmbeddedFont[]>([]);
+    }
+
+    const pdf = this.pdfiumModule.pdfium;
+    const fonts = new Map<number, PdfDocumentEmbeddedFont>();
+
+    const registerFont = (fontPtr: number): void => {
+      if (!fontPtr || fonts.has(fontPtr)) {
+        return;
+      }
+
+      const isEmbedded = !!this.pdfiumModule.FPDFFont_GetIsEmbedded(fontPtr);
+      if (!isEmbedded) {
+        return;
+      }
+
+      const baseNameRaw = readString(
+        pdf,
+        (buffer, bufferLength) =>
+          this.pdfiumModule.FPDFFont_GetBaseFontName(fontPtr, buffer, bufferLength),
+        pdf.UTF8ToString,
+      ).trim();
+      const baseName = baseNameRaw.length ? baseNameRaw : undefined;
+
+      let subsetTag: string | undefined;
+      let postScriptName: string | undefined = baseName;
+      if (baseName && baseName.includes('+')) {
+        const [tag, rest] = baseName.split('+', 2);
+        if (tag && /^[A-Z]{6}$/.test(tag)) {
+          subsetTag = tag;
+        }
+        postScriptName = rest && rest.length ? rest : baseName;
+      }
+
+      const familyRaw = readString(
+        pdf,
+        (buffer, bufferLength) =>
+          this.pdfiumModule.FPDFFont_GetFamilyName(fontPtr, buffer, bufferLength),
+        pdf.UTF8ToString,
+      ).trim();
+      const family = familyRaw.length ? familyRaw : undefined;
+
+      const flagsValue = this.pdfiumModule.FPDFFont_GetFlags(fontPtr);
+      const flags = Number.isFinite(flagsValue) ? flagsValue : undefined;
+
+      const weightValue = this.pdfiumModule.FPDFFont_GetWeight(fontPtr);
+      const weight = Number.isFinite(weightValue) && weightValue > 0 ? weightValue : undefined;
+
+      let italicAngle: number | undefined;
+      const italicAnglePtr = this.memoryManager.malloc(4);
+      if (this.pdfiumModule.FPDFFont_GetItalicAngle(fontPtr, italicAnglePtr)) {
+        italicAngle = pdf.getValue(italicAnglePtr, 'i32');
+      }
+      this.memoryManager.free(italicAnglePtr);
+
+      let ascent: number | undefined;
+      let descent: number | undefined;
+      const ascentPtr = this.memoryManager.malloc(4);
+      const descentPtr = this.memoryManager.malloc(4);
+      if (this.pdfiumModule.FPDFFont_GetAscent(fontPtr, 1, ascentPtr)) {
+        ascent = pdf.getValue(ascentPtr, 'float');
+      }
+      if (this.pdfiumModule.FPDFFont_GetDescent(fontPtr, 1, descentPtr)) {
+        descent = pdf.getValue(descentPtr, 'float');
+      }
+      this.memoryManager.free(ascentPtr);
+      this.memoryManager.free(descentPtr);
+
+      const lengthPtr = this.memoryManager.malloc(4);
+      let data: Uint8Array | undefined;
+      let dataLength: number | undefined;
+      try {
+        this.pdfiumModule.FPDFFont_GetFontData(fontPtr, 0, 0, lengthPtr);
+        const requestedLength = pdf.getValue(lengthPtr, 'i32');
+        if (requestedLength > 0) {
+          dataLength = requestedLength;
+          const MAX_FONT_BYTES = 32 * 1024 * 1024;
+          if (requestedLength <= MAX_FONT_BYTES) {
+            const bufferPtr = this.memoryManager.malloc(requestedLength);
+            try {
+              const ok = this.pdfiumModule.FPDFFont_GetFontData(
+                fontPtr,
+                bufferPtr,
+                requestedLength,
+                lengthPtr,
+              );
+              const actualLength = pdf.getValue(lengthPtr, 'i32');
+              if (ok && actualLength > 0 && actualLength <= MAX_FONT_BYTES) {
+                dataLength = actualLength;
+                const heap = pdf.HEAPU8;
+                data = new Uint8Array(actualLength);
+                data.set(heap.subarray(bufferPtr, bufferPtr + actualLength));
+              }
+            } finally {
+              this.memoryManager.free(bufferPtr);
+            }
+          }
+        }
+      } finally {
+        this.memoryManager.free(lengthPtr);
+      }
+
+      const ITALIC_FLAGS = 0x20 | 0x40;
+      const italicFlag = typeof flags === 'number' && (flags & ITALIC_FLAGS) !== 0;
+      const italic = italicFlag || (typeof italicAngle === 'number' && italicAngle !== 0);
+
+      fonts.set(fontPtr, {
+        id: `font-${fontPtr.toString(16)}`,
+        baseName,
+        postScriptName,
+        subsetTag,
+        family,
+        flags,
+        weight,
+        italic,
+        italicAngle,
+        ascent,
+        descent,
+        data,
+        dataLength,
+        isEmbedded,
+      });
+    };
+
+    const visitObject = (objectPtr: number): void => {
+      if (!objectPtr) return;
+      const type = this.pdfiumModule.FPDFPageObj_GetType(objectPtr);
+      if (type === PdfPageObjectType.FORM) {
+        const childCount = this.pdfiumModule.FPDFFormObj_CountObjects(objectPtr);
+        for (let i = 0; i < childCount; i++) {
+          const childPtr = this.pdfiumModule.FPDFFormObj_GetObject(objectPtr, i);
+          visitObject(childPtr);
+        }
+        return;
+      }
+
+      if (type === PdfPageObjectType.TEXT) {
+        const fontPtr = this.pdfiumModule.FPDFTextObj_GetFont(objectPtr) as number;
+        if (fontPtr) {
+          registerFont(fontPtr);
+        }
+      }
+    };
+
+    for (let pageIndex = 0; pageIndex < doc.pageCount; pageIndex++) {
+      ctx.borrowPage(pageIndex, (pageCtx) => {
+        const objectCount = this.pdfiumModule.FPDFPage_CountObjects(pageCtx.pagePtr);
+        for (let objectIndex = 0; objectIndex < objectCount; objectIndex++) {
+          const objPtr = this.pdfiumModule.FPDFPage_GetObject(pageCtx.pagePtr, objectIndex);
+          visitObject(objPtr);
+        }
+      });
+    }
+
+    return PdfTaskHelper.resolve(Array.from(fonts.values()));
+  }
+
+  /**
    * Walk the tagged structure tree of a page and return a hierarchy of elements
    * including tag name, text content, bounding rectangle and MCID references.
    */
@@ -8341,7 +8507,6 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       };
 
       entry.rect = entry.rect ? unionRect(entry.rect, rect) : rect;
-
     };
 
     const objectCount = this.pdfiumModule.FPDFPage_CountObjects(pageCtx.pagePtr);
@@ -8353,7 +8518,13 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
     const readFontInfo = (charIndex: number): PdfStructElementFont | undefined => {
       let family: string | undefined;
       let flags: number | undefined;
-      const fontNameLength = this.pdfiumModule.FPDFText_GetFontInfo(textPagePtr, charIndex, 0, 0, 0);
+      const fontNameLength = this.pdfiumModule.FPDFText_GetFontInfo(
+        textPagePtr,
+        charIndex,
+        0,
+        0,
+        0,
+      );
       if (fontNameLength > 0) {
         const bytes = fontNameLength + 1; // include NIL
         const textBufferPtr = this.memoryManager.malloc(bytes);
@@ -8378,7 +8549,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
 
       const ITALIC_FLAGS = 0x20 | 0x40;
       const FORCE_BOLD_FLAG = 0x100;
-      const italic = !!(flags && (flags & ITALIC_FLAGS));
+      const italic = !!(flags && flags & ITALIC_FLAGS);
       if (flags && flags & FORCE_BOLD_FLAG) {
         fontWeight = Math.max(fontWeight ?? 600, 600);
       }
@@ -8454,11 +8625,11 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
         run.pageLeft = run.pageLeft === undefined ? left : Math.min(run.pageLeft, left);
         run.pageRight = run.pageRight === undefined ? right : Math.max(run.pageRight, right);
         run.pageTop = run.pageTop === undefined ? top : Math.max(run.pageTop, top);
-        run.pageBottom =
-          run.pageBottom === undefined ? bottom : Math.min(run.pageBottom, bottom);
+        run.pageBottom = run.pageBottom === undefined ? bottom : Math.min(run.pageBottom, bottom);
       }
 
-      run.firstIndex = run.firstIndex === undefined ? charIndex : Math.min(run.firstIndex, charIndex);
+      run.firstIndex =
+        run.firstIndex === undefined ? charIndex : Math.min(run.firstIndex, charIndex);
       run.lastIndex = run.lastIndex === undefined ? charIndex : Math.max(run.lastIndex, charIndex);
 
       if (!entry.font && fontInfo) {
@@ -8473,11 +8644,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
           ? glyph.charCode
           : this.pdfiumModule.FPDFText_GetUnicode(textPagePtr, charIndex);
       const char =
-        charCode && charCode > 0
-          ? String.fromCodePoint(charCode)
-          : glyph.isSpace
-          ? ' '
-          : '';
+        charCode && charCode > 0 ? String.fromCodePoint(charCode) : glyph.isSpace ? ' ' : '';
 
       if (char) {
         entry.text += char;
@@ -8498,8 +8665,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       };
     };
 
-    const getLeft = (run: McidRunAccumulator) =>
-      run.pageLeft ?? (run.rect ? run.rect.origin.x : 0);
+    const getLeft = (run: McidRunAccumulator) => run.pageLeft ?? (run.rect ? run.rect.origin.x : 0);
     const getRight = (run: McidRunAccumulator) =>
       run.pageRight ?? (run.rect ? run.rect.origin.x + run.rect.size.width : getLeft(run));
     const getTop = (run: McidRunAccumulator) =>
@@ -8597,22 +8763,22 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
             last.firstIndex =
               last.firstIndex !== undefined && current.firstIndex !== undefined
                 ? Math.min(last.firstIndex, current.firstIndex)
-                : last.firstIndex ?? current.firstIndex;
-              last.lastIndex =
-                last.lastIndex !== undefined && current.lastIndex !== undefined
-                  ? Math.max(last.lastIndex, current.lastIndex)
-                  : last.lastIndex ?? current.lastIndex;
-              if (!last.font && current.font) {
-                last.font = { ...current.font };
-              }
-              if (!last.matrix && current.matrix) {
-                last.matrix = { ...current.matrix };
-              }
-              continue;
+                : (last.firstIndex ?? current.firstIndex);
+            last.lastIndex =
+              last.lastIndex !== undefined && current.lastIndex !== undefined
+                ? Math.max(last.lastIndex, current.lastIndex)
+                : (last.lastIndex ?? current.lastIndex);
+            if (!last.font && current.font) {
+              last.font = { ...current.font };
             }
+            if (!last.matrix && current.matrix) {
+              last.matrix = { ...current.matrix };
+            }
+            continue;
           }
-          merged.push(current);
         }
+        merged.push(current);
+      }
       return merged;
     };
 

--- a/packages/engines/src/lib/webworker/engine.ts
+++ b/packages/engines/src/lib/webworker/engine.ts
@@ -23,6 +23,7 @@ import {
   PdfGlyphObject,
   PdfPageGeometry,
   PdfStructElement,
+  PdfDocumentEmbeddedFont,
   PageTextSlice,
   AnnotationCreateContext,
   PdfEngineMethodArgs,
@@ -592,6 +593,20 @@ export class WebWorkerEngine implements PdfEngine {
     const task = new WorkerTask<PdfTextRectObject[]>(this.worker, requestId);
 
     const request: ExecuteRequest = createRequest(requestId, 'getPageTextRects', [doc, page]);
+    this.proxy(task, request);
+
+    return task;
+  }
+
+  /**
+   * Fetch all embedded fonts for the specified document.
+   */
+  getDocumentEmbeddedFonts(doc: PdfDocumentObject) {
+    this.logger.debug(LOG_SOURCE, LOG_CATEGORY, 'getDocumentEmbeddedFonts', doc);
+    const requestId = this.generateRequestId(doc.id);
+    const task = new WorkerTask<PdfDocumentEmbeddedFont[]>(this.worker, requestId);
+
+    const request: ExecuteRequest = createRequest(requestId, 'getDocumentEmbeddedFonts', [doc]);
     this.proxy(task, request);
 
     return task;

--- a/packages/engines/src/lib/webworker/runner.ts
+++ b/packages/engines/src/lib/webworker/runner.ts
@@ -381,6 +381,9 @@ export class EngineRunner {
       case 'getStructTree':
         task = this.engine[name]!(...args);
         break;
+      case 'getDocumentEmbeddedFonts':
+        task = this.engine[name]!(...args);
+        break;
       case 'searchAllPages':
         task = this.engine[name]!(...args);
         break;

--- a/packages/models/src/pdf.ts
+++ b/packages/models/src/pdf.ts
@@ -2243,6 +2243,70 @@ export interface PdfStructElementFont {
 }
 
 /**
+ * Embedded font information extracted from a PDF document
+ *
+ * @public
+ */
+export interface PdfDocumentEmbeddedFont {
+  /**
+   * Stable identifier for the font within the document
+   */
+  id: string;
+  /**
+   * Base font name (may include subset prefix)
+   */
+  baseName?: string;
+  /**
+   * PostScript font name without subset prefix
+   */
+  postScriptName?: string;
+  /**
+   * Subset tag (characters before '+') if present
+   */
+  subsetTag?: string;
+  /**
+   * Reported family name
+   */
+  family?: string;
+  /**
+   * Raw font descriptor flags
+   */
+  flags?: number;
+  /**
+   * Nominal font weight
+   */
+  weight?: number;
+  /**
+   * Whether the font is marked as italic
+   */
+  italic?: boolean;
+  /**
+   * Italic angle reported by PDFium
+   */
+  italicAngle?: number;
+  /**
+   * Normalised ascent value (for size = 1)
+   */
+  ascent?: number;
+  /**
+   * Normalised descent value (for size = 1)
+   */
+  descent?: number;
+  /**
+   * Raw embedded font data (if available)
+   */
+  data?: Uint8Array;
+  /**
+   * Length of the embedded font data in bytes
+   */
+  dataLength?: number;
+  /**
+   * Whether PDFium reported the font as embedded
+   */
+  isEmbedded: boolean;
+}
+
+/**
  * Text matrix describing the transform from text space to user space.
  *
  * @public
@@ -2922,6 +2986,12 @@ export interface PdfEngine<T = Blob> {
    * @returns task that contains the structural elements
    */
   getStructTree?: (doc: PdfDocumentObject, page: PdfPageObject) => PdfTask<PdfStructElement[]>;
+  /**
+   * Extract embedded fonts from the document
+   * @param doc - pdf document
+   * @returns task containing embedded fonts metadata and binary data
+   */
+  getDocumentEmbeddedFonts?: (doc: PdfDocumentObject) => PdfTask<PdfDocumentEmbeddedFont[]>;
   /**
    * Search across all pages in the document
    * @param doc - pdf document

--- a/packages/plugin-a11y/src/lib/a11y-plugin.ts
+++ b/packages/plugin-a11y/src/lib/a11y-plugin.ts
@@ -82,7 +82,7 @@ export class A11yPlugin extends BasePlugin<A11yPluginConfig, A11yCapability> {
     try {
       const fonts = await engine.getDocumentEmbeddedFonts(doc).toPromise();
       if (Array.isArray(fonts)) {
-        registerDocumentFonts(doc.id, fonts);
+        await registerDocumentFonts(doc.id, fonts);
       }
     } catch (error) {
       this.logger.warn('A11yPlugin', 'Fonts', 'Unable to register embedded fonts', error);

--- a/packages/plugin-a11y/src/lib/a11y-plugin.ts
+++ b/packages/plugin-a11y/src/lib/a11y-plugin.ts
@@ -1,4 +1,5 @@
-import { BasePlugin, PluginRegistry } from '@embedpdf/core';
+import { BasePlugin, CoreState, PluginRegistry, StoreState } from '@embedpdf/core';
+import { PdfDocumentObject } from '@embedpdf/models';
 
 import {
   A11yCapability,
@@ -7,12 +8,14 @@ import {
   StructElementFont,
   StructElementTextRun,
 } from './types';
-import { mapPdfTagToHtml } from './utils';
+import { mapPdfTagToHtml, resetA11yStyles } from './utils';
+import { registerDocumentFonts, resetFontRegistry } from './font-registry';
 
 export class A11yPlugin extends BasePlugin<A11yPluginConfig, A11yCapability> {
   static readonly id = 'a11y' as const;
 
   private config: A11yPluginConfig = { debug: false };
+  private fontsReady: Promise<void> = Promise.resolve();
 
   constructor(id: string, registry: PluginRegistry) {
     super(id, registry);
@@ -37,7 +40,58 @@ export class A11yPlugin extends BasePlugin<A11yPluginConfig, A11yCapability> {
     return classes.join(' ');
   }
 
+  protected override onCoreStoreUpdated(
+    oldState: StoreState<CoreState>,
+    newState: StoreState<CoreState>,
+  ): void {
+    const oldDocId = oldState.core.document?.id ?? null;
+    const newDoc = newState.core.document ?? null;
+    const newDocId = newDoc?.id ?? null;
+
+    if (oldDocId === newDocId) {
+      return;
+    }
+
+    this.fontsReady = this.loadFontsForDocument(newDoc);
+    this.fontsReady.catch((error) => {
+      this.logger.warn('A11yPlugin', 'Fonts', 'Failed to prepare embedded fonts', error);
+    });
+  }
+
+  private async waitForFontsReady(): Promise<void> {
+    try {
+      await this.fontsReady;
+    } catch (error) {
+      this.logger.debug('A11yPlugin', 'Fonts', 'Falling back to default fonts', error);
+    }
+  }
+
+  private async loadFontsForDocument(doc: PdfDocumentObject | null): Promise<void> {
+    resetFontRegistry();
+    resetA11yStyles();
+
+    if (!doc) {
+      return;
+    }
+
+    const engine: any = this.engine as any;
+    if (typeof engine.getDocumentEmbeddedFonts !== 'function') {
+      return;
+    }
+
+    try {
+      const fonts = await engine.getDocumentEmbeddedFonts(doc).toPromise();
+      if (Array.isArray(fonts)) {
+        registerDocumentFonts(doc.id, fonts);
+      }
+    } catch (error) {
+      this.logger.warn('A11yPlugin', 'Fonts', 'Unable to register embedded fonts', error);
+    }
+  }
+
   private async getStructElements(pageIndex: number): Promise<StructElement[]> {
+    await this.waitForFontsReady();
+
     const coreState = this.coreState.core;
     if (!coreState.document) {
       throw new Error('document does not open');

--- a/packages/plugin-a11y/src/lib/constants.ts
+++ b/packages/plugin-a11y/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const A11yLayerClassName = 'embedpdf-a11y-layer';

--- a/packages/plugin-a11y/src/lib/font-registry.ts
+++ b/packages/plugin-a11y/src/lib/font-registry.ts
@@ -1,0 +1,192 @@
+import { PdfDocumentEmbeddedFont } from '@embedpdf/models';
+
+import { a11yStyleSheet } from './stylesheet';
+
+const pdfFontNameToCss = new Map<string, string | null>();
+let fontCounter = 0;
+
+const SUPPORTED_FORMATS: Record<string, { mime: string; cssFormat: string }> = {
+  woff2: { mime: 'font/woff2', cssFormat: 'woff2' },
+  woff: { mime: 'font/woff', cssFormat: 'woff' },
+  truetype: { mime: 'font/ttf', cssFormat: 'truetype' },
+  opentype: { mime: 'font/otf', cssFormat: 'opentype' },
+};
+
+type SupportedFormatKey = keyof typeof SUPPORTED_FORMATS;
+
+type DetectedFormat = {
+  key: SupportedFormatKey;
+  mime: string;
+  cssFormat: string;
+};
+
+function detectFontFormat(data: Uint8Array): DetectedFormat | null {
+  if (data.length < 4) return null;
+
+  const signature = String.fromCharCode(data[0], data[1], data[2], data[3]);
+  if (signature === 'wOF2') {
+    return { key: 'woff2', ...SUPPORTED_FORMATS.woff2 };
+  }
+  if (signature === 'wOFF') {
+    return { key: 'woff', ...SUPPORTED_FORMATS.woff };
+  }
+  if (signature === 'OTTO') {
+    return { key: 'opentype', ...SUPPORTED_FORMATS.opentype };
+  }
+  if (signature === 'true') {
+    return { key: 'truetype', ...SUPPORTED_FORMATS.truetype };
+  }
+  if (signature === '\u0000\u0001\u0000\u0000') {
+    return { key: 'truetype', ...SUPPORTED_FORMATS.truetype };
+  }
+
+  // TrueType collections start with 'ttcf'. They are not directly usable as webfonts.
+  if (signature === 'ttcf') {
+    return null;
+  }
+
+  // Bare CFF fonts start with 0x01 0x00 0x04 0x00; treat as unsupported for now.
+  if (data[0] === 0x01 && data[1] === 0x00 && data[2] === 0x04 && data[3] === 0x00) {
+    return null;
+  }
+
+  // PDF can embed Type1 ("%!PS") or other formats which are not usable directly.
+  if (signature === '%!PS') {
+    return null;
+  }
+
+  return null;
+}
+
+function toBase64(data: Uint8Array): string {
+  const maybeBuffer = (
+    globalThis as { Buffer?: { from(data: Uint8Array): { toString(encoding: string): string } } }
+  ).Buffer;
+  if (maybeBuffer && typeof maybeBuffer.from === 'function') {
+    return maybeBuffer.from(data).toString('base64');
+  }
+
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < data.length; i += chunkSize) {
+    const chunk = data.subarray(i, Math.min(data.length, i + chunkSize));
+    binary += String.fromCharCode(...chunk);
+  }
+  const base64Encoder = (globalThis as { btoa?: (data: string) => string }).btoa;
+  if (typeof base64Encoder === 'function') {
+    return base64Encoder(binary);
+  }
+  throw new Error('Base64 encoding is not supported in this environment.');
+}
+
+function normaliseName(name: string): string {
+  return name.trim();
+}
+
+function setNameMapping(name: string, cssFamily: string | null) {
+  const trimmed = normaliseName(name);
+  if (!trimmed.length) {
+    return;
+  }
+  pdfFontNameToCss.set(trimmed, cssFamily);
+  pdfFontNameToCss.set(trimmed.toLowerCase(), cssFamily);
+}
+
+function registerFontFace(font: PdfDocumentEmbeddedFont): string | undefined {
+  if (!font.data || !font.data.length) {
+    return undefined;
+  }
+
+  const detected = detectFontFormat(font.data);
+  if (!detected) {
+    return undefined;
+  }
+
+  fontCounter += 1;
+  const cssFamily = `embedpdf-font-${fontCounter}`;
+
+  const base64 = toBase64(font.data);
+  const descriptors: string[] = [];
+  descriptors.push(`font-family: "${cssFamily}"`);
+  descriptors.push(
+    `src: url("data:${detected.mime};base64,${base64}") format('${detected.cssFormat}')`,
+  );
+  descriptors.push('font-display: swap');
+
+  if (typeof font.weight === 'number' && Number.isFinite(font.weight) && font.weight > 0) {
+    descriptors.push(`font-weight: ${Math.round(font.weight)}`);
+  }
+
+  const isItalic =
+    font.italic === true || (typeof font.italicAngle === 'number' && font.italicAngle !== 0);
+  if (isItalic) {
+    descriptors.push('font-style: italic');
+  }
+
+  const rule = `@font-face { ${descriptors.join('; ')}; }`;
+
+  try {
+    a11yStyleSheet.insertRule(rule, a11yStyleSheet.cssRules.length);
+    return cssFamily;
+  } catch (error) {
+    const logger = (globalThis as { console?: { warn?: (...args: unknown[]) => void } }).console;
+    logger?.warn?.('[A11yPlugin] Failed to register font face', font.baseName ?? font.id, error);
+    return undefined;
+  }
+}
+
+function collectFontNames(font: PdfDocumentEmbeddedFont): string[] {
+  const names = new Set<string>();
+  if (font.baseName) {
+    names.add(font.baseName);
+  }
+  if (font.postScriptName) {
+    names.add(font.postScriptName);
+  }
+  if (font.subsetTag && font.postScriptName) {
+    names.add(`${font.subsetTag}+${font.postScriptName}`);
+  }
+  if (font.family) {
+    names.add(font.family);
+  }
+  return Array.from(names);
+}
+
+export function resetFontRegistry(): void {
+  pdfFontNameToCss.clear();
+  fontCounter = 0;
+}
+
+export function registerDocumentFonts(_docId: string, fonts: PdfDocumentEmbeddedFont[]): void {
+  const seen = new Set<string>();
+  for (const font of fonts) {
+    if (seen.has(font.id)) {
+      continue;
+    }
+    seen.add(font.id);
+
+    const cssFamily = registerFontFace(font);
+    const names = collectFontNames(font);
+    if (names.length === 0 && cssFamily) {
+      // Still allow lookup via generated family if no names available.
+      setNameMapping(font.id, cssFamily);
+    }
+
+    for (const name of names) {
+      setNameMapping(name, cssFamily ?? null);
+    }
+  }
+}
+
+export function resolveFontFamily(pdfFontName: string | undefined): string | undefined {
+  if (!pdfFontName) return undefined;
+  const direct = pdfFontNameToCss.get(pdfFontName);
+  if (direct) {
+    return direct;
+  }
+  if (direct === null) {
+    return undefined;
+  }
+  const lower = pdfFontNameToCss.get(pdfFontName.toLowerCase());
+  return lower ?? undefined;
+}

--- a/packages/plugin-a11y/src/lib/font-registry.ts
+++ b/packages/plugin-a11y/src/lib/font-registry.ts
@@ -1,9 +1,13 @@
 import { PdfDocumentEmbeddedFont } from '@embedpdf/models';
-
-import { a11yStyleSheet } from './stylesheet';
+import { blob } from 'stream/consumers';
 
 const pdfFontNameToCss = new Map<string, string | null>();
 let fontCounter = 0;
+const registeredFontFaces: FontFace[] = [];
+
+function warn(...args: unknown[]): void {
+  (globalThis as { console?: { warn?: (...args: unknown[]) => void } }).console?.warn?.(...args);
+}
 
 const SUPPORTED_FORMATS: Record<string, { mime: string; cssFormat: string }> = {
   woff2: { mime: 'font/woff2', cssFormat: 'woff2' },
@@ -79,6 +83,16 @@ function toBase64(data: Uint8Array): string {
   throw new Error('Base64 encoding is not supported in this environment.');
 }
 
+function sliceToArrayBuffer(data: Uint8Array): ArrayBuffer {
+  if (
+    data.byteOffset === 0 &&
+    data.byteLength === data.buffer.byteLength
+  ) {
+    return data.buffer;
+  }
+  return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+}
+
 function normaliseName(name: string): string {
   return name.trim();
 }
@@ -92,7 +106,7 @@ function setNameMapping(name: string, cssFamily: string | null) {
   pdfFontNameToCss.set(trimmed.toLowerCase(), cssFamily);
 }
 
-function registerFontFace(font: PdfDocumentEmbeddedFont): string | undefined {
+async function registerFontFace(font: PdfDocumentEmbeddedFont): Promise<string | undefined> {
   if (!font.data || !font.data.length) {
     return undefined;
   }
@@ -105,32 +119,45 @@ function registerFontFace(font: PdfDocumentEmbeddedFont): string | undefined {
   fontCounter += 1;
   const cssFamily = `embedpdf-font-${fontCounter}`;
 
-  const base64 = toBase64(font.data);
-  const descriptors: string[] = [];
-  descriptors.push(`font-family: "${cssFamily}"`);
-  descriptors.push(
-    `src: url("data:${detected.mime};base64,${base64}") format('${detected.cssFormat}')`,
-  );
-  descriptors.push('font-display: swap');
-
-  if (typeof font.weight === 'number' && Number.isFinite(font.weight) && font.weight > 0) {
-    descriptors.push(`font-weight: ${Math.round(font.weight)}`);
-  }
-
+  const finiteWeight =
+    typeof font.weight === 'number' && Number.isFinite(font.weight) && font.weight > 0
+      ? Math.round(font.weight)
+      : undefined;
+  const weightDescriptor = finiteWeight !== undefined ? String(finiteWeight) : undefined;
   const isItalic =
     font.italic === true || (typeof font.italicAngle === 'number' && font.italicAngle !== 0);
-  if (isItalic) {
-    descriptors.push('font-style: italic');
+  const styleDescriptor = isItalic ? 'italic' : 'normal';
+
+  const FontFaceCtor = (globalThis as { FontFace?: typeof FontFace }).FontFace;
+  const doc = (globalThis as { document?: Document }).document;
+  const fontSet = doc?.fonts;
+
+  if (!FontFaceCtor || !fontSet) {
+    warn(
+      '[A11yPlugin] FontFace API unavailable; embedded font cannot be loaded',
+      font.baseName ?? font.id,
+    );
+    return undefined;
   }
 
-  const rule = `@font-face { ${descriptors.join('; ')}; }`;
-
   try {
-    a11yStyleSheet.insertRule(rule, a11yStyleSheet.cssRules.length);
+    const descriptors: FontFaceDescriptors = { style: styleDescriptor };
+    if (weightDescriptor) {
+      descriptors.weight = weightDescriptor;
+    }
+
+    const binary = sliceToArrayBuffer(font.data);
+    console.log("TTF stream: ", URL.createObjectURL(new Blob([binary])));
+    const fontFace = new FontFaceCtor(cssFamily, binary, descriptors);
+    if ('display' in fontFace) {
+      (fontFace as FontFace & { display?: string }).display = 'swap';
+    }
+    await fontFace.load();
+    fontSet.add(fontFace);
+    registeredFontFaces.push(fontFace);
     return cssFamily;
   } catch (error) {
-    const logger = (globalThis as { console?: { warn?: (...args: unknown[]) => void } }).console;
-    logger?.warn?.('[A11yPlugin] Failed to register font face', font.baseName ?? font.id, error);
+    warn('[A11yPlugin] Failed to load font via FontFace API', font.baseName ?? font.id, error);
     return undefined;
   }
 }
@@ -155,27 +182,58 @@ function collectFontNames(font: PdfDocumentEmbeddedFont): string[] {
 export function resetFontRegistry(): void {
   pdfFontNameToCss.clear();
   fontCounter = 0;
+
+  const doc = (globalThis as { document?: Document }).document;
+  const fontSet = doc?.fonts;
+  if (fontSet) {
+    for (const face of registeredFontFaces) {
+      try {
+        if (typeof fontSet.delete === 'function') {
+          fontSet.delete(face);
+        }
+      } catch (error) {
+        warn('[A11yPlugin] Failed to remove font face', face.family, error);
+      }
+    }
+  }
+  registeredFontFaces.length = 0;
 }
 
-export function registerDocumentFonts(_docId: string, fonts: PdfDocumentEmbeddedFont[]): void {
+export async function registerDocumentFonts(
+  _docId: string,
+  fonts: PdfDocumentEmbeddedFont[],
+): Promise<void> {
   const seen = new Set<string>();
+  const registrations: Array<Promise<void>> = [];
   for (const font of fonts) {
     if (seen.has(font.id)) {
       continue;
     }
     seen.add(font.id);
 
-    const cssFamily = registerFontFace(font);
-    const names = collectFontNames(font);
-    if (names.length === 0 && cssFamily) {
-      // Still allow lookup via generated family if no names available.
-      setNameMapping(font.id, cssFamily);
-    }
+    registrations.push(
+      (async () => {
+        let cssFamily: string | undefined;
+        try {
+          cssFamily = await registerFontFace(font);
+        } catch (error) {
+          warn('[A11yPlugin] Unexpected error while registering font', font.baseName ?? font.id, error);
+          cssFamily = undefined;
+        }
 
-    for (const name of names) {
-      setNameMapping(name, cssFamily ?? null);
-    }
+        const names = collectFontNames(font);
+        if (names.length === 0) {
+          setNameMapping(font.id, cssFamily ?? null);
+        }
+
+        for (const name of names) {
+          setNameMapping(name, cssFamily ?? null);
+        }
+      })(),
+    );
   }
+
+  await Promise.all(registrations);
 }
 
 export function resolveFontFamily(pdfFontName: string | undefined): string | undefined {

--- a/packages/plugin-a11y/src/lib/stylesheet.ts
+++ b/packages/plugin-a11y/src/lib/stylesheet.ts
@@ -1,0 +1,27 @@
+import { A11yLayerClassName } from './constants';
+
+export const A11Y_BASE_STYLES = `
+  .${A11yLayerClassName}, .${A11yLayerClassName} * {
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    font-family: Sans-Serif;
+  }
+  .${A11yLayerClassName} * {
+    white-space: pre;
+    font-kerning: none;
+  }
+  .${A11yLayerClassName} .textrun {
+    overflow: visible;
+    display: inline-block;
+    overflow: hidden;
+  }
+`;
+
+export const a11yStyleSheet = new CSSStyleSheet();
+a11yStyleSheet.replaceSync(A11Y_BASE_STYLES);
+
+export function resetA11yStyleSheet(): void {
+  a11yStyleSheet.replaceSync(A11Y_BASE_STYLES);
+}

--- a/packages/plugin-a11y/src/lib/utils.ts
+++ b/packages/plugin-a11y/src/lib/utils.ts
@@ -1,61 +1,46 @@
+import { A11yLayerClassName } from './constants';
+import { resolveFontFamily } from './font-registry';
+import { a11yStyleSheet, resetA11yStyleSheet } from './stylesheet';
+
 const TAG_MAP: Record<string, string> = {
-  Document: "section",
-  Part: "section",
-  Sect: "section",
-  Div: "div",
-  P: "p",
-  Span: "span",
-  H: "h1",
-  H1: "h1",
-  H2: "h2",
-  H3: "h3",
-  H4: "h4",
-  H5: "h5",
-  H6: "h6",
-  L: "ul",
-  LI: "li",
-  LBody: "ul",
-  Table: "table",
-  TR: "tr",
-  TH: "th",
-  TD: "td",
-  Figure: "figure",
-  Caption: "figcaption",
+  Document: 'section',
+  Part: 'section',
+  Sect: 'section',
+  Div: 'div',
+  P: 'p',
+  Span: 'span',
+  H: 'h1',
+  H1: 'h1',
+  H2: 'h2',
+  H3: 'h3',
+  H4: 'h4',
+  H5: 'h5',
+  H6: 'h6',
+  L: 'ul',
+  LI: 'li',
+  LBody: 'ul',
+  Table: 'table',
+  TR: 'tr',
+  TH: 'th',
+  TD: 'td',
+  Figure: 'figure',
+  Caption: 'figcaption',
 };
 
 export function mapPdfTagToHtml(tag: string): string {
-  return TAG_MAP[tag] ?? "span";
+  return TAG_MAP[tag] ?? 'span';
 }
 
-export const A11yLayerClassName = "embedpdf-a11y-layer";
-const styleSheet = new CSSStyleSheet();
-styleSheet.replaceSync(`
-  .${A11yLayerClassName}, .${A11yLayerClassName} * {
-    pointer-events: none;
-    position: absolute;
-    top: 0;
-    left: 0;
-    font-family: Sans-Serif;
-  }
-  .${A11yLayerClassName} * {
-    white-space: pre;
-    font-kerning: none;
-  }
-  .${A11yLayerClassName} .textrun {
-    overflow: visible;
-    display: inline-block;
-    overflow: hidden;
-  }
-`);
+export { A11yLayerClassName } from './constants';
 
 export function translateFontFamily(fontFamily: string | undefined): string | undefined {
   if (!fontFamily) return undefined;
-  if (fontFamily.includes("-")) {
-    return `${fontFamily}, ${fontFamily.split("-")[0]}, sans-serif`;
+  if (fontFamily.includes('-')) {
+    return `${fontFamily}, ${fontFamily.split('-')[0]}, sans-serif`;
   }
-  if (fontFamily.includes("Helvetica")) return "Helvetica, Arial, sans-serif";
-  if (fontFamily.includes("Times")) return "Times New Roman, serif";
-  if (fontFamily.includes("Courier")) return "Courier New, monospace";
+  if (fontFamily.includes('Helvetica')) return 'Helvetica, Arial, sans-serif';
+  if (fontFamily.includes('Times')) return 'Times New Roman, serif';
+  if (fontFamily.includes('Courier')) return 'Courier New, monospace';
   return fontFamily;
 }
 
@@ -79,8 +64,21 @@ export function getFontClassName(
   const className = `ft-${fontClassNameMap.size + 1}`;
   const declarations: string[] = [];
 
-  if (fontFamily) {
-    declarations.push(`font-family: ${translateFontFamily(fontFamily)};`);
+  const resolvedFamily = resolveFontFamily(fontFamily);
+  if (resolvedFamily) {
+    const fallback = translateFontFamily(fontFamily);
+    const families = [`"${resolvedFamily}"`];
+    if (fallback && !fallback.toLowerCase().includes(resolvedFamily.toLowerCase())) {
+      families.push(fallback);
+    } else if (fallback && !fallback.startsWith('"')) {
+      families.push(fallback);
+    }
+    declarations.push(`font-family: ${families.join(', ')};`);
+  } else if (fontFamily) {
+    const fallback = translateFontFamily(fontFamily);
+    if (fallback) {
+      declarations.push(`font-family: ${fallback};`);
+    }
   }
   if (fontSize !== undefined) {
     declarations.push(`font-size: calc(var(--scale, 1) * ${fontSize.toFixed(2)}px);`);
@@ -92,9 +90,9 @@ export function getFontClassName(
     declarations.push('font-style: italic;');
   }
 
-  styleSheet.insertRule(
+  a11yStyleSheet.insertRule(
     `.${A11yLayerClassName} .${className} { ${declarations.join(' ')} }`,
-    styleSheet.cssRules.length,
+    a11yStyleSheet.cssRules.length,
   );
   fontClassNameMap.set(fontIdentifier, className);
   return className;
@@ -110,17 +108,23 @@ export function getLineHeightClass(lineHeightPx: number | undefined): string | u
   if (cached) return cached;
 
   const className = `lh-${lineHeightClassMap.size + 1}`;
-  styleSheet.insertRule(
+  a11yStyleSheet.insertRule(
     `.${A11yLayerClassName} .${className} { line-height: ${lineHeightPx.toFixed(2)}px; }`,
-    styleSheet.cssRules.length,
+    a11yStyleSheet.cssRules.length,
   );
   lineHeightClassMap.set(key, className);
   return className;
 }
 
 export function adoptA11yLayerStyleSheet(host: Document | ShadowRoot) {
-  if (host.adoptedStyleSheets.includes(styleSheet)) {
+  if (host.adoptedStyleSheets.includes(a11yStyleSheet)) {
     return;
   }
-  host.adoptedStyleSheets = [...host.adoptedStyleSheets, styleSheet];
+  host.adoptedStyleSheets = [...host.adoptedStyleSheets, a11yStyleSheet];
+}
+
+export function resetA11yStyles(): void {
+  fontClassNameMap.clear();
+  lineHeightClassMap.clear();
+  resetA11yStyleSheet();
 }


### PR DESCRIPTION
## Summary
- add PdfDocumentEmbeddedFont model and expose a getDocumentEmbeddedFonts engine capability
- teach the PDFium engine to extract embedded fonts and register them with the a11y plugin
- add a font registry and stylesheet helpers so the a11y layer can inject @font-face rules for extracted fonts

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb70ae3ed0832da283fbbcd5870bce